### PR TITLE
refactor: centralize pack configuration

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback, useReducer } from 'react';
 
 // --- CONFIGS & SERVICES (chemins standardisés) ---
-import { PACKS } from './packs';
+import PACKS from '../../shared/packs.js';
 import { initialCustomFilters, customFilterReducer } from './state/filterReducer';
 import { loadProfileWithDefaults, saveProfile } from './services/PlayerProfile';
 import { checkNewAchievements, ACHIEVEMENTS } from './achievements';

--- a/client/src/Configurator.jsx
+++ b/client/src/Configurator.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PACKS } from './packs';
+import PACKS from '../../shared/packs.js';
 import CustomFilter from './CustomFilter';
 
 function Configurator({ onStartGame, error, activePackId, setActivePackId, customFilters, dispatch }) {

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
+  server: {
+    fs: {
+      allow: ['..']
+    }
+  },
   plugins: [
     react(),
     VitePWA({

--- a/server.js
+++ b/server.js
@@ -4,17 +4,12 @@ const cors = require('cors');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const PACKS = require('./shared/packs');
 
-// La définition des packs est dupliquée ici pour que le serveur soit autonome.
-// Dans une application plus grande, ce fichier pourrait être partagé.
-const PACKS_CONFIG = [
-    { id: 'world_birds', api_params: { taxon_id: '3', popular: 'true' } },
-    { id: 'france_mammals', api_params: { taxon_id: '40151', place_id: '6753' } },
-    { id: 'belgium_herps', api_params: { taxon_id: '26036,20978', place_id: '6911' }},
-    { id: 'amazing_insects', api_params: { taxon_id: '47158', popular: 'true' }},
-    { id: 'mediterranean_flora', api_params: { taxon_id: '47126', place_id: '53832' }},
-    { id: 'great_barrier_reef_life', api_params: { taxon_id: '1', place_id: '131021' }}
-];
+// On extrait uniquement les packs dynamiques pour le backend
+const PACKS_CONFIG = PACKS
+  .filter(p => p.api_params)
+  .map(({ id, api_params }) => ({ id, api_params }));
 
 const allowedOrigins = [
   'https://inaturamouche.netlify.app', // Votre frontend en production

--- a/shared/packs.js
+++ b/shared/packs.js
@@ -1,8 +1,7 @@
-// On importe les listes de données statiques
-import europeanMushrooms from './common_european_mushrooms.json';
-import europeanTrees from './common_european_trees.json';
+const europeanMushrooms = require('../client/src/common_european_mushrooms.json');
+const europeanTrees = require('../client/src/common_european_trees.json');
 
-export const PACKS = [
+const PACKS = [
   {
     id: 'custom',
     type: 'custom', // Un type spécial pour notre filtre avancé
@@ -12,14 +11,14 @@ export const PACKS = [
   {
     id: 'european_mushrooms',
     type: 'list', // Ce pack est basé sur une liste d'IDs
-    title: 'Champignons commestibles d\'europe',
+    title: "Champignons commestibles d'europe",
     description: 'Une sélection des champignons les plus communs en Europe.',
     taxa_ids: europeanMushrooms.map(m => m.inaturalist_id)
   },
   {
     id: 'european_trees',
     type: 'list',
-    title: 'Arbres communs d\'europe',
+    title: "Arbres communs d'europe",
     description: 'Une sélection des arbres les plus communs en Europe.',
     taxa_ids: europeanTrees.map(t => t.inaturalist_id)
   },
@@ -27,7 +26,7 @@ export const PACKS = [
     id: 'world_birds',
     type: 'dynamic', // Ce pack sera interprété par le backend
     title: 'Oiseaux du monde',
-    description: 'Les 100 espèces d\'oiseaux les plus observées sur iNaturalist.',
+    description: "Les 100 espèces d'oiseaux les plus observées sur iNaturalist.",
     api_params: { taxon_id: '3', popular: 'true' }
   },
   {
@@ -56,17 +55,19 @@ export const PACKS = [
     type: 'dynamic',
     title: 'Flore méditerranéenne',
     description: 'Les plantes, arbres et fleurs typiques du bassin méditerranéen.',
-    api_params: { taxon_id: '47126', place_id: '53832', popular: 'true',}
+    api_params: { taxon_id: '47126', place_id: '53832', popular: 'true' }
   },
   {
-  id: 'great_barrier_reef_life',
-  type: 'dynamic',
-  title: 'Vie marine de la grande barrière de corail',
-  description: 'Poissons, coraux et mollusques du plus grand récif corallien du monde.',
-  api_params: {
-    taxon_id: '1',      // ID pour le règne Animalia (Animaux)
-    place_id: '131021',  // ID iNaturalist pour le Parc marin de la Grande Barrière de Corail
-    popular: 'true',
-  }
-},
+    id: 'great_barrier_reef_life',
+    type: 'dynamic',
+    title: 'Vie marine de la grande barrière de corail',
+    description: 'Poissons, coraux et mollusques du plus grand récif corallien du monde.',
+    api_params: {
+      taxon_id: '1',      // ID pour le règne Animalia (Animaux)
+      place_id: '131021',  // ID iNaturalist pour le Parc marin de la Grande Barrière de Corail
+      popular: 'true',
+    }
+  },
 ];
+
+module.exports = PACKS;


### PR DESCRIPTION
## Summary
- move pack definitions into shared module
- load shared pack config on server and client
- allow Vite dev server to access shared files

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` (from `client`, fails: Package subpath './config' is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a814f2f1d48333b343f2cf86fb08ef