### PR TITLE
feat: optimize image handling

### DIFF
--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './ImageViewer.css';
+import { getSizedImageUrl } from '../utils/imageUtils';
 
 // Constante pour le niveau de zoom
 const ZOOM_LEVEL = 2.5;
@@ -122,8 +123,11 @@ function ImageViewer({ imageUrls, alt }) {
         onMouseLeave={handleMouseLeave}
       >
         <img
-          src={imageUrls[currentIndex]}
+          src={getSizedImageUrl(imageUrls[currentIndex], 'large')}
+          srcSet={`${getSizedImageUrl(imageUrls[currentIndex], 'small')} 300w, ${getSizedImageUrl(imageUrls[currentIndex], 'medium')} 600w, ${getSizedImageUrl(imageUrls[currentIndex], 'large')} 1024w`}
+          sizes="(max-width: 600px) 100vw, 600px"
           alt={alt}
+          loading="lazy"
           style={{
             transform: `translateX(${transform.x}px) translateY(${transform.y}px) scale(${isZoomed ? ZOOM_LEVEL : 1}) rotate(${rotation}deg)`,
             transition: isPanning.current ? 'none' : 'transform 0.3s ease', // Désactive la transition pendant le déplacement pour plus de fluidité

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import './RoundSummaryModal.css';
+import { getSizedImageUrl } from '../utils/imageUtils';
 
 const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
   if (!question || !question.bonne_reponse) {
@@ -30,7 +31,14 @@ const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
         
         <div className="correct-answer-section">
           <p>La réponse était :</p>
-          <img src={imageUrl} alt={commonName || scientificName} className="answer-image" />
+          <img
+            src={getSizedImageUrl(imageUrl, 'large')}
+            srcSet={`${getSizedImageUrl(imageUrl, 'small')} 300w, ${getSizedImageUrl(imageUrl, 'medium')} 600w, ${getSizedImageUrl(imageUrl, 'large')} 1024w`}
+            sizes="(max-width: 600px) 100vw, 400px"
+            alt={commonName || scientificName}
+            className="answer-image"
+            loading="lazy"
+          />
           
           {/* On affiche le nom commun que s'il existe ET est différent du nom scientifique */}
           {displayCommonName && (

--- a/client/src/utils/imageUtils.js
+++ b/client/src/utils/imageUtils.js
@@ -1,0 +1,8 @@
+// Utility functions for handling image URLs
+
+// Replace size segment in iNaturalist image URLs to request different sizes
+export function getSizedImageUrl(url, size) {
+  if (!url) return url;
+  return url.replace(/(square|small|medium|large|original)/, size);
+}
+


### PR DESCRIPTION
## Summary
- lazy-load viewer images and serve responsive sizes
- use responsive sizes and lazy loading for round summary image
- add image URL utility

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` (client) (fails: Missing script "test")
- `npm run lint` (client) (fails: Package subpath './config' is not defined by "exports" in eslint package)


------
https://chatgpt.com/codex/tasks/task_e_68a81549d1248333bfa9b4237c9a5d37