### PR TITLE
feat: cache iNaturalist images and add offline fallback

### DIFF
--- a/client/public/offline.html
+++ b/client/public/offline.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8">
+    <title>Hors ligne</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body { display: flex; justify-content: center; align-items: center; min-height: 100vh; font-family: sans-serif; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <p>Vous êtes hors ligne. Veuillez vérifier votre connexion.</p>
+  </body>
+</html>

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'assets/*.png'],
+      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'assets/*.png', 'offline.html'],
       manifest: {
         name: 'Inaturamouche',
         short_name: 'Inaturamouche',
@@ -35,7 +35,27 @@ export default defineConfig({
             purpose: 'any maskable'
           }
         ]
+      },
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/static\.inaturalist\.org\/.*$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'inaturalist-images',
+              cacheableResponse: {
+                statuses: [0, 200]
+              },
+              expiration: {
+                maxEntries: 60,
+                maxAgeSeconds: 60 * 60 * 24 * 30
+              }
+            }
+          }
+        ],
+        navigateFallback: '/offline.html'
       }
     })
   ],
 })
+


### PR DESCRIPTION
## Summary
- cache iNaturalist images using Workbox runtime caching
- add minimal offline fallback page and include it in PWA assets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint package)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8155215b883339f9c8702024f4645