### PR TITLE
Add aria-label to modal close buttons

### DIFF
--- a/client/src/components/HelpModal.jsx
+++ b/client/src/components/HelpModal.jsx
@@ -9,7 +9,7 @@ function HelpModal({ onClose }) {
     <div className="modal-backdrop" onClick={onClose}>
       {/* On empêche la propagation du clic pour que le modal ne se ferme pas quand on clique dessus */}
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-        <button onClick={onClose} className="close-button" title="Fermer">×</button>
+        <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>
         
         <h2 className="modal-title">Bienvenue sur Inaturamouche !</h2>
         

--- a/client/src/components/ProfileModal.jsx
+++ b/client/src/components/ProfileModal.jsx
@@ -80,7 +80,7 @@ function ProfileModal({ profile, onClose }) {
   return (
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal-content profile-modal" onClick={(e) => e.stopPropagation()}>
-        <button onClick={onClose} className="close-button" title="Fermer">×</button>
+        <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>
         <h2 className="modal-title">Profil du Joueur</h2>
 
         <div className="tabs-container">


### PR DESCRIPTION
## Summary
- ensure modal close buttons expose an accessible `aria-label`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Package subpath './config' is not defined by "exports" in eslint package)*

------
https://chatgpt.com/codex/tasks/task_e_68a8158580fc83338faf8d72f76f7d17