### PR TITLE
feat: track accuracy and per-pack statistics

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -157,13 +157,19 @@ function App() {
       
       updatedProfile.xp = (updatedProfile.xp || 0) + finalScoreInGame;
       updatedProfile.stats.gamesPlayed = (updatedProfile.stats.gamesPlayed || 0) + 1;
-      
+
       if(gameMode === 'easy') {
         updatedProfile.stats.correctEasy = (updatedProfile.stats.correctEasy || 0) + finalCorrectAnswersInSession;
         updatedProfile.stats.easyQuestionsAnswered = (updatedProfile.stats.easyQuestionsAnswered || 0) + MAX_QUESTIONS_PER_GAME;
+        updatedProfile.stats.accuracyEasy = updatedProfile.stats.easyQuestionsAnswered > 0
+          ? updatedProfile.stats.correctEasy / updatedProfile.stats.easyQuestionsAnswered
+          : 0;
       } else { // mode 'hard'
         updatedProfile.stats.correctHard = (updatedProfile.stats.correctHard || 0) + finalCorrectAnswersInSession;
         updatedProfile.stats.hardQuestionsAnswered = (updatedProfile.stats.hardQuestionsAnswered || 0) + MAX_QUESTIONS_PER_GAME;
+        updatedProfile.stats.accuracyHard = updatedProfile.stats.hardQuestionsAnswered > 0
+          ? updatedProfile.stats.correctHard / updatedProfile.stats.hardQuestionsAnswered
+          : 0;
       }
 
       // Le reste de la logique pour la maîtrise, les packs et les succès
@@ -174,7 +180,11 @@ function App() {
       });
 
       if (!updatedProfile.stats.packsPlayed) updatedProfile.stats.packsPlayed = {};
-      updatedProfile.stats.packsPlayed[activePackId] = (updatedProfile.stats.packsPlayed[activePackId] || 0) + 1;
+      if (!updatedProfile.stats.packsPlayed[activePackId]) {
+        updatedProfile.stats.packsPlayed[activePackId] = { correct: 0, answered: 0 };
+      }
+      updatedProfile.stats.packsPlayed[activePackId].correct += finalCorrectAnswersInSession;
+      updatedProfile.stats.packsPlayed[activePackId].answered += MAX_QUESTIONS_PER_GAME;
 
       const unlockedIds = checkNewAchievements(updatedProfile);
       if (unlockedIds.length > 0) {

--- a/client/src/components/ProfileModal.jsx
+++ b/client/src/components/ProfileModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ACHIEVEMENTS } from '../achievements';
 import './ProfileModal.css';
 import { getTaxaByIds } from '../services/api';
+import PACKS from '../../../shared/packs.js';
 
 // --- Fonctions de calcul pour le système de niveaux ---
 const getLevelFromXp = (xp) => {
@@ -76,6 +77,8 @@ function ProfileModal({ profile, onClose }) {
   const totalAnswered = (profile.stats.easyQuestionsAnswered || 0) + (profile.stats.hardQuestionsAnswered || 0);
   const totalCorrect = (profile.stats.correctEasy || 0) + (profile.stats.correctHard || 0);
   const overallAccuracy = totalAnswered > 0 ? ((totalCorrect / totalAnswered) * 100).toFixed(1) : "0.0";
+  const easyAccuracy = ((profile.stats.accuracyEasy || 0) * 100).toFixed(1);
+  const hardAccuracy = ((profile.stats.accuracyHard || 0) * 100).toFixed(1);
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
@@ -116,10 +119,42 @@ function ProfileModal({ profile, onClose }) {
           {activeTab === 'stats' && (
             <div className="fade-in">
               <div className="profile-section">
+                <h3>Précision par mode</h3>
+                <div className="stats-grid">
+                  <div className="stat-item">
+                    <span className="stat-value">{easyAccuracy}%</span>
+                    <span className="stat-label">Mode Facile</span>
+                  </div>
+                  <div className="stat-item">
+                    <span className="stat-value">{hardAccuracy}%</span>
+                    <span className="stat-label">Mode Difficile</span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="profile-section">
+                <h3>Statistiques par Pack</h3>
+                <ul className="pack-stats-list">
+                  {Object.entries(profile.stats.packsPlayed || {}).map(([packId, { correct, answered }]) => {
+                    const pack = PACKS.find(p => p.id === packId);
+                    const acc = answered > 0 ? ((correct / answered) * 100).toFixed(1) : '0.0';
+                    return (
+                      <li key={packId} className="pack-stat-item">
+                        <span className="pack-name">{pack ? pack.title : packId}</span>
+                        <span className="pack-count">{correct}/{answered} ({acc}%)</span>
+                      </li>
+                    );
+                  })}
+                  {Object.keys(profile.stats.packsPlayed || {}).length === 0 && (
+                    <p className="empty-state">Aucun pack joué.</p>
+                  )}
+                </ul>
+              </div>
+
+              <div className="profile-section">
                 <h3>Maîtrise (Top 5)</h3>
                 {isLoadingMastery ? <p>Chargement...</p> : (
                   <ul className="mastery-list">
-                    {/* --- CORRECTION 3 : On peut maintenant utiliser l'ID en toute sécurité --- */}
                     {masteryDetails.map(({ id, taxon, count }) => (
                       <MasteryItem key={id} taxon={taxon} count={count} />
                     ))}

--- a/client/src/services/PlayerProfile.js
+++ b/client/src/services/PlayerProfile.js
@@ -11,8 +11,10 @@ const getDefaultProfile = () => ({
     hardQuestionsAnswered: 0,
     correctEasy: 0,
     correctHard: 0,
+    accuracyEasy: 0,
+    accuracyHard: 0,
     speciesMastery: {}, // ex: { taxonId: count, ... }
-    packsPlayed: {}
+    packsPlayed: {},
   },
   achievements: [],
 });
@@ -36,8 +38,23 @@ export const loadProfileWithDefaults = () => {
         ...(loadedProfile.stats || {}),
       },
     };
+    // Migration des anciennes structures packsPlayed qui stockaient simplement un nombre
+    if (finalProfile.stats.packsPlayed) {
+      const migrated = {};
+      Object.entries(finalProfile.stats.packsPlayed).forEach(([packId, data]) => {
+        if (typeof data === 'number') {
+          migrated[packId] = { correct: 0, answered: 0 };
+        } else {
+          migrated[packId] = {
+            correct: data.correct || 0,
+            answered: data.answered || 0,
+          };
+        }
+      });
+      finalProfile.stats.packsPlayed = migrated;
+    }
     // On supprime l'ancienne clé totalScore pour faire le ménage
-    delete finalProfile.totalScore; 
+    delete finalProfile.totalScore;
 
     return finalProfile;
 


### PR DESCRIPTION
## Summary
- add easy and hard mode accuracy fields to player profile
- compute and persist accuracy and per-pack correct/answered totals after each game
- display mode accuracies and pack totals in profile statistics modal

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])

------
https://chatgpt.com/codex/tasks/task_e_68a8c7d1b9408333a75d2a8707d489a5