### PR TITLE
feat: enhance end screen stats

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -237,7 +237,14 @@ function App() {
                 : <HardMode question={question} score={score} onNextQuestion={handleNextQuestion} onQuit={returnToConfig} />
             )
         ) : isGameOver ? (
-          <EndScreen score={score} onRestart={startGame} />
+          <EndScreen
+            score={score}
+            sessionStats={sessionStats}
+            sessionCorrectSpecies={sessionCorrectSpecies}
+            newlyUnlocked={newlyUnlocked}
+            onRestart={startGame}
+            onShowProfile={() => setIsProfileVisible(true)}
+          />
         ) : (
           <div className="screen configurator-screen">
             <div className="card">

--- a/client/src/components/EndScreen.jsx
+++ b/client/src/components/EndScreen.jsx
@@ -1,13 +1,43 @@
 import React from 'react';
+import { ACHIEVEMENTS } from '../achievements';
 
-const EndScreen = ({ score, onRestart }) => (
-  <div className="screen end-screen">
-    <div className="card">
-      <h1>Partie terminée !</h1>
-      <h2>Votre score final : <span className="score">{score}</span></h2>
-      <button onClick={onRestart} className="start-button">Rejouer</button>
+const EndScreen = ({
+  score,
+  sessionStats,
+  sessionCorrectSpecies = [],
+  newlyUnlocked = [],
+  onRestart,
+  onShowProfile,
+}) => {
+  const totalQuestions = sessionStats?.totalQuestions || 5;
+  const accuracy = ((sessionStats?.correctAnswers || 0) / totalQuestions) * 100;
+  const speciesCount = new Set(sessionCorrectSpecies).size;
+
+  return (
+    <div className="screen end-screen">
+      <div className="card">
+        <h1>Partie terminée !</h1>
+        <h2>
+          Votre score final : <span className="score">{score}</span>
+        </h2>
+        <p>Précision : {accuracy.toFixed(0)}%</p>
+        <p>Espèces correctement identifiées : {speciesCount}</p>
+        {newlyUnlocked.length > 0 && (
+          <div className="achievements">
+            <h3>Succès débloqués :</h3>
+            <ul>
+              {newlyUnlocked.map((id) => (
+                <li key={id}>{ACHIEVEMENTS[id]?.title || id}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <button onClick={onRestart} className="start-button">Rejouer</button>
+        <button onClick={onShowProfile}>Voir mon profil</button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default EndScreen;
+


### PR DESCRIPTION
## Summary
- pass session stats, species list and achievements to end screen
- show accuracy, species count and unlocked achievements on end screen
- add profile shortcut button on end screen

## Testing
- `npm test` (fails: Error: no test specified)
- `cd client && npm run lint` (fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])

------
https://chatgpt.com/codex/tasks/task_e_68a8c7e225ec8333bc7f8bf7110f7044