### PR TITLE
feat: add titles to game mode buttons

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -248,11 +248,23 @@ function App() {
               >
                 ?
               </button>
-               <div className="mode-selector">
-                  <h3>Choisir le mode :</h3>
-                  <button onClick={() => setGameMode('easy')} className={gameMode === 'easy' ? 'active' : ''}>Facile</button>
-                  <button onClick={() => setGameMode('hard')} className={gameMode === 'hard' ? 'active' : ''}>Difficile</button>
-              </div>
+                 <div className="mode-selector">
+                    <h3>Choisir le mode :</h3>
+                    <button
+                      onClick={() => setGameMode('easy')}
+                      className={gameMode === 'easy' ? 'active' : ''}
+                      title="Mode facile : choix multiple"
+                    >
+                      Facile
+                    </button>
+                    <button
+                      onClick={() => setGameMode('hard')}
+                      className={gameMode === 'hard' ? 'active' : ''}
+                      title="Mode difficile : réponse libre"
+                    >
+                      Difficile
+                    </button>
+                </div>
               <Configurator 
                 onStartGame={startGame} 
                 error={error}


### PR DESCRIPTION
## Summary
- add tooltip titles to easy and hard mode buttons

## Testing
- `npm test`
- `npm run lint` *(fails: Error [ERR_PACKAGE_PATH_NOT_EXPORTED])*

------
https://chatgpt.com/codex/tasks/task_e_68a8c9bbc31483338276f3b75a256d3a