### PR TITLE
feat: add home intro component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,7 @@ import EndScreen from './components/EndScreen';
 import Spinner from './components/Spinner';
 import HelpModal from './components/HelpModal';
 import ProfileModal from './components/ProfileModal';
+import HomeIntro from './components/HomeIntro';
 import titleImage from './assets/inaturamouche-title.png';
 
 // --- STYLES ---
@@ -49,6 +50,7 @@ function App() {
   const [isHelpVisible, setIsHelpVisible] = useState(false);
   const [newlyUnlocked, setNewlyUnlocked] = useState([]);
   const [sessionCorrectSpecies, setSessionCorrectSpecies] = useState([]);
+  const [showHomeIntro, setShowHomeIntro] = useState(() => !localStorage.getItem('home_intro_seen'));
 
   const handleProfileReset = () => {
     setPlayerProfile(loadProfileWithDefaults());
@@ -275,7 +277,8 @@ function App() {
               >
                 ?
               </button>
-                 <div className="mode-selector">
+              {showHomeIntro && <HomeIntro onClose={() => setShowHomeIntro(false)} />}
+              <div className="mode-selector">
                     <h3>Choisir le mode :</h3>
                     <button
                       onClick={() => setGameMode('easy')}

--- a/client/src/components/HomeIntro.jsx
+++ b/client/src/components/HomeIntro.jsx
@@ -1,0 +1,21 @@
+// src/components/HomeIntro.jsx
+
+import React from 'react';
+
+function HomeIntro({ onClose }) {
+  const handleClose = () => {
+    localStorage.setItem('home_intro_seen', '1');
+    onClose();
+  };
+
+  return (
+    <div className="home-intro">
+      <p><strong>Principe :</strong> identifiez des espèces à partir de photos issues d'iNaturalist.</p>
+      <p><strong>Modes :</strong> Facile (QCM) ou Difficile (classification complète).</p>
+      <p><strong>Packs :</strong> choisissez un thème prédéfini ou créez le vôtre.</p>
+      <button onClick={handleClose} className="start-button-modal">Compris</button>
+    </div>
+  );
+}
+
+export default HomeIntro;


### PR DESCRIPTION
## Summary
- add HomeIntro component summarising game basics
- show HomeIntro once before mode selector using localStorage

## Testing
- `npm test` (fails: Error: no test specified)
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce08102c8333b2e4e4cdf8ea137e