### PR TITLE
Focus HelpModal content on open

### DIFF
--- a/client/src/components/HelpModal.jsx
+++ b/client/src/components/HelpModal.jsx
@@ -1,14 +1,18 @@
 // src/components/HelpModal.jsx
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import './HelpModal.css'; // Nous allons créer ce fichier CSS juste après
 
 function HelpModal({ onClose }) {
+  useEffect(() => {
+    document.querySelector('.modal-content')?.focus();
+  }, []);
+
   return (
     // Le fond assombri qui ferme le modal au clic
     <div className="modal-backdrop" onClick={onClose}>
       {/* On empêche la propagation du clic pour que le modal ne se ferme pas quand on clique dessus */}
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-content" tabIndex="-1" onClick={(e) => e.stopPropagation()}>
         <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>
         
         <h2 className="modal-title">Bienvenue sur Inaturamouche !</h2>


### PR DESCRIPTION
## Summary
- Focus modal content once HelpModal opens for better keyboard navigation
- Allow modal content to receive focus by adding tabIndex

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3200b9883338a7fe2f38acddf00