### PR TITLE
Add global focus outline for keyboard navigation

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -64,3 +64,7 @@ h2 {
 button {
   font-family: var(--font-family-main);
 }
+:focus {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add :focus outline to improve keyboard navigation visibility

## Testing
- `npm test` (fails: Error: no test specified)
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a8d3aed44883338d77bb53a99d1b9f