### PR TITLE
Utilise clamp pour titres responsives

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -46,7 +46,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-  font-size: 2.2em;
+  font-size: clamp(1.5rem, 2vw, 2.2rem);
   font-weight: 700;
   line-height: 1.1;
   color: var(--text-color);
@@ -54,7 +54,7 @@ h1 {
 }
 
 h2 {
-  font-size: 1.8em;
+  font-size: clamp(1.2rem, 1.5vw, 1.8rem);
   font-weight: 500;
   line-height: 1.1;
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- rende les titres h1/h2 responsives via `font-size: clamp`

## Testing
- `node - <<'NODE'` (calcul des tailles aux largeurs 320/768/1024/1440)
- `npm test` *(échoue : Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3d6fbc083339980a20fcd6240a1