### PR TITLE
Handle Escape key in RoundSummaryModal

### DIFF
--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -1,12 +1,25 @@
 // src/components/RoundSummaryModal.jsx (version finale corrigée)
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import './RoundSummaryModal.css';
 import { getSizedImageUrl } from '../utils/imageUtils';
 
 const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onNext();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onNext]);
+
   if (!question || !question.bonne_reponse) {
-    return null; 
+    return null;
   }
 
   const { bonne_reponse, inaturalist_url } = question;


### PR DESCRIPTION
## Summary
- handle Escape key to trigger onNext in round summary modal

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68a8d44095348333ad4f88ae2cd420ae