### PR TITLE
feat: add revision mode and species mastery tracking

### DIFF
--- a/client/src/Configurator.jsx
+++ b/client/src/Configurator.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PACKS from '../../shared/packs.js';
 import CustomFilter from './CustomFilter';
 
-function Configurator({ onStartGame, error, activePackId, setActivePackId, customFilters, dispatch }) {
+function Configurator({ onStartGame, onStartReview, hasMissedSpecies, error, activePackId, setActivePackId, customFilters, dispatch }) {
 
   // On trouve les détails du pack actuellement sélectionné pour afficher sa description
 
@@ -40,6 +40,9 @@ function Configurator({ onStartGame, error, activePackId, setActivePackId, custo
       </div>
 
       <button onClick={onStartGame} className="start-button">Lancer la partie !</button>
+      {hasMissedSpecies && (
+        <button onClick={onStartReview} className="start-button">Réviser mes erreurs</button>
+      )}
     </div>
   );
 }

--- a/client/src/achievements.js
+++ b/client/src/achievements.js
@@ -36,7 +36,8 @@ export const checkNewAchievements = (profile) => {
       unlocked.push('ACCURACY_HARD_75');
     }
 
-    const masteredSpeciesCount = Object.values(stats.speciesMastery || {}).filter(count => count >= 3).length;
+    const masteredSpeciesCount = Object.values(stats.speciesMastery || {})
+      .filter(m => (m.correct || 0) >= 3).length;
     if (masteredSpeciesCount >= 5 && !achievements.includes('MASTER_5_SPECIES')) {
       unlocked.push('MASTER_5_SPECIES');
     }

--- a/client/src/components/ProfileModal.jsx
+++ b/client/src/components/ProfileModal.jsx
@@ -35,6 +35,7 @@ function ProfileModal({ profile, onClose, onResetProfile }) {
   const [isLoadingMastery, setIsLoadingMastery] = useState(false);
 
   const sortedMastery = Object.entries(profile?.stats?.speciesMastery || {})
+                              .map(([id, data]) => [id, data.correct || 0])
                               .sort(([,a],[,b]) => b - a)
                               .slice(0, 5);
 


### PR DESCRIPTION
## Summary
- add profile migration and cleanup for missed species and mastery data
- enable revision sessions focusing on missed species and remove them once answered
- count mastered species from new `speciesMastery.correct` structure and expose review button in configurator

## Testing
- `npm test` *(fails: Error: no test specified)*
- `(cd client && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8d72253bc8333bec37ec2c027accc