### PR TITLE
Allow closing modals with Escape key

### DIFF
--- a/client/src/components/HelpModal.jsx
+++ b/client/src/components/HelpModal.jsx
@@ -5,8 +5,19 @@ import './HelpModal.css'; // Nous allons créer ce fichier CSS juste après
 
 function HelpModal({ onClose }) {
   useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
     document.querySelector('.modal-content')?.focus();
-  }, []);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
 
   return (
     // Le fond assombri qui ferme le modal au clic

--- a/client/src/components/ProfileModal.jsx
+++ b/client/src/components/ProfileModal.jsx
@@ -39,6 +39,19 @@ function ProfileModal({ profile, onClose, onResetProfile }) {
                               .slice(0, 5);
 
   useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
     if (activeTab !== 'stats' || !profile || sortedMastery.length === 0 || masteryDetails.length > 0) return;
     const fetchMasteryDetails = async () => {
       setIsLoadingMastery(true);


### PR DESCRIPTION
## Summary
- enable closing HelpModal via Escape key
- allow closing ProfileModal via Escape key

## Testing
- `npm test` (fails: no test specified)
- `npm --prefix client run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8d8404c0483339c2c1cc24459b45e