### PR TITLE
Improve end-of-game summary and navigation

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -157,14 +157,25 @@ button:focus-visible {
   text-align: left;
 }
 .end-screen .species-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: var(--space-3);
+}
+.end-screen .species-info {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.end-screen .species-status {
+  margin-left: 0.5rem;
 }
 .end-screen .species-common {
   font-weight: 500;
   margin-right: 0.25rem;
 }
 .end-screen .external-links-container {
-  justify-content: flex-start;
+  display: flex;
   gap: 0.5rem;
 }
   .mode-selector { display: flex; align-items: center; gap: 1rem; margin-bottom: var(--space-5); padding: var(--space-3); background-color: rgba(0,0,0,0.1); border-radius: var(--border-radius); justify-content: center; }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -332,12 +332,11 @@ const handleProfileReset = () => {
         ) : isGameOver ? (
           <EndScreen
             score={score}
-            sessionStats={sessionStats}
             sessionCorrectSpecies={sessionCorrectSpecies}
             sessionSpeciesData={sessionSpeciesData}
             newlyUnlocked={newlyUnlocked}
             onRestart={startGame}
-            onShowProfile={() => setIsProfileVisible(true)}
+            onReturnHome={returnToConfig}
           />
         ) : (
           <div className="screen configurator-screen">

--- a/client/src/components/EndScreen.jsx
+++ b/client/src/components/EndScreen.jsx
@@ -3,36 +3,39 @@ import { ACHIEVEMENTS } from '../achievements';
 
 const EndScreen = ({
   score,
-  sessionStats,
   sessionCorrectSpecies = [],
   sessionSpeciesData = [],
   newlyUnlocked = [],
   onRestart,
-  onShowProfile,
+  onReturnHome,
 }) => {
-  const totalQuestions = sessionStats?.totalQuestions || 5;
-  const accuracy = ((sessionStats?.correctAnswers || 0) / totalQuestions) * 100;
-  const speciesCount = new Set(sessionCorrectSpecies).size;
+  const totalQuestions = sessionSpeciesData.length || 0;
+  const correctCount = sessionCorrectSpecies.length;
+  const accuracy = totalQuestions > 0 ? (correctCount / totalQuestions) * 100 : 0;
+  const isWin = correctCount >= Math.ceil(totalQuestions / 2);
 
   return (
     <div className="screen end-screen">
       <div className="card">
-        <h1>Partie terminée !</h1>
+        <h1>{isWin ? 'Victoire !' : 'Défaite'}</h1>
         <h2>
           Votre score final : <span className="score">{score}</span>
         </h2>
         <p>Précision : {accuracy.toFixed(0)}%</p>
-        <p>Espèces correctement identifiées : {speciesCount}</p>
         {sessionSpeciesData.length > 0 && (
           <div className="played-species">
             <h3>Espèces rencontrées :</h3>
             <ul className="species-list">
               {sessionSpeciesData.map((sp) => {
                 const displayCommon = sp.common_name && sp.common_name !== sp.name ? sp.common_name : null;
+                const isFound = sessionCorrectSpecies.includes(sp.id);
                 return (
                   <li key={sp.id}>
-                    {displayCommon && <span className="species-common">{displayCommon}</span>}
-                    <em>{sp.name}</em>
+                    <div className="species-info">
+                      {displayCommon && <span className="species-common">{displayCommon}</span>}
+                      <em>{sp.name}</em>
+                      <span className="species-status">{isFound ? '✅' : '❌'}</span>
+                    </div>
                     <div className="external-links-container">
                       <a
                         href={sp.inaturalist_url}
@@ -70,7 +73,7 @@ const EndScreen = ({
           </div>
         )}
         <button onClick={onRestart} className="start-button">Rejouer</button>
-        <button onClick={onShowProfile}>Voir mon profil</button>
+        <button onClick={onReturnHome}>Accueil</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show victory/defeat with accurate stats at game end
- list each played species with wiki and iNaturalist links plus status icons
- add home button and flex layout for end screen links

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8de08d5cc8333a413d19ee17e126c