### PR TITLE
Add preconnect and dns-prefetch hints

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,8 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Inaturamouche</title>
 
+    <link rel="preconnect" href="https://api.inaturalist.org" />
+    <link rel="dns-prefetch" href="https://api.inaturalist.org" />
+    <link rel="preconnect" href="https://static.inaturalist.org" />
+    <link rel="dns-prefetch" href="https://static.inaturalist.org" />
+    <link rel="preconnect" href="https://tile.openstreetmap.org" />
+    <link rel="dns-prefetch" href="https://tile.openstreetmap.org" />
+
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    
+
     </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- preconnect to external APIs and map tiles
- hint DNS prefetch for iNaturalist and OpenStreetMap resources

## Testing
- `npm test` (fails: Error: no test specified)
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8e2b1308333847e3288f94ec563