### PR TITLE
feat: lazy load map filter

### DIFF
--- a/client/src/CustomFilter.jsx
+++ b/client/src/CustomFilter.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import AutocompleteInput from './AutocompleteInput';
-import MapFilter from './MapFilter';
+const MapFilter = lazy(() => import('./MapFilter'));
 
 const TaxonPill = ({ taxon, onRemove }) => (
   <div className="taxon-pill">
@@ -66,7 +66,11 @@ function CustomFilter({ filters, dispatch }) {
             Filtrer par Lieu
           </label>
         </legend>
-        {filters.place_enabled && <MapFilter filters={filters} dispatch={dispatch} />}
+        {filters.place_enabled && (
+          <Suspense fallback={<div>Chargement de la carte...</div>}>
+            <MapFilter filters={filters} dispatch={dispatch} />
+          </Suspense>
+        )}
       </fieldset>
 
       <fieldset>

--- a/client/src/MapFilter.jsx
+++ b/client/src/MapFilter.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { MapContainer, TileLayer, Circle, useMapEvents } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
 
 // Ce sous-composant gère les interactions avec la carte
 function MapLogic({ center, radius, dispatch }) {

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,7 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import 'leaflet/dist/leaflet.css';
 import App from './App.jsx'
 import { registerSW } from 'virtual:pwa-register'
 


### PR DESCRIPTION
## Summary
- lazy-load MapFilter component behind React.Suspense
- move Leaflet stylesheet import into MapFilter to avoid global load

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8d0e5b483339400aa0dcc549aa2