### PR TITLE
Add compression, helmet and cache control

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   "description": "",
   "dependencies": {
     "axios": "^1.10.0",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "helmet": "^7.0.0",
     "react-medium-image-zoom": "^5.2.14"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,10 +1,16 @@
 import express from 'express';
 import axios from 'axios';
 import cors from 'cors';
+import compression from 'compression';
+import helmet from 'helmet';
 import PACKS from './shared/packs.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+
+// Sécurisation et optimisation des réponses HTTP
+app.use(helmet());
+app.use(compression());
 
 // Les packs sont maintenant partagés avec le client.
 
@@ -23,6 +29,12 @@ const corsOptions = {
   }
 };
 app.use(cors(corsOptions));
+
+// Gestion du cache pour toutes les réponses
+app.use((req, res, next) => {
+  res.set('Cache-Control', 'public, max-age=300, stale-while-revalidate=3600');
+  next();
+});
 
 // --- FONCTIONS UTILITAIRES ---
 async function getFullTaxaDetails(taxonIds, locale = 'fr') {


### PR DESCRIPTION
## Summary
- add helmet and compression middleware for security and performance
- globally set Cache-Control header for cached responses

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68a8e8daee948333ae00a4684d502770