### PR TITLE
Add network-first cache for iNaturalist API requests

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -59,6 +59,13 @@ export default defineConfig({
                 maxAgeSeconds: 60 * 60 * 24 * 30
               }
             }
+          },
+          {
+            urlPattern: /^https:\/\/api\.inaturalist\.org/,
+            handler: 'NetworkFirst',
+            options: {
+              networkTimeoutSeconds: 3
+            }
           }
         ],
         navigateFallback: '/offline.html'


### PR DESCRIPTION
## Summary
- cache iNaturalist API calls with a NetworkFirst strategy and 3s timeout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8ee4ec88333a1b81bd1c7772562