### PR TITLE
Memoize TaxonPill and map center

### DIFF
--- a/client/src/CustomFilter.jsx
+++ b/client/src/CustomFilter.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import AutocompleteInput from './AutocompleteInput';
 import MapFilter from './MapFilter';
 
-const TaxonPill = ({ taxon, onRemove }) => (
+const TaxonPill = React.memo(({ taxon, onRemove }) => (
   <div className="taxon-pill">
     <span>{taxon.name}</span>
     <button onClick={onRemove} className="remove-btn" title="Retirer ce taxon">×</button>
   </div>
-);
+));
 
 function CustomFilter({ filters, dispatch }) {
 

--- a/client/src/MapFilter.jsx
+++ b/client/src/MapFilter.jsx
@@ -22,7 +22,7 @@ function MapLogic({ center, radius, dispatch }) {
 // Le composant principal du filtre de carte
 function MapFilter({ filters, dispatch }) {
   const { lat, lng, radius } = filters;
-  const center = { lat, lng };
+  const center = useMemo(() => ({ lat, lng }), [lat, lng]);
 
   const handleRadiusChange = (e) => {
     const newRadius = Number(e.target.value);
@@ -59,3 +59,4 @@ function MapFilter({ filters, dispatch }) {
 }
 
 export default MapFilter;
+


### PR DESCRIPTION
## Summary
- avoid unnecessary re-renders by memoizing `TaxonPill`
- memoize map `center` object with `useMemo` for stable reference

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e92692d48333a4e7c2febb9ed4c1