### PR TITLE
chore: improve help button accessibility

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -346,6 +346,7 @@ const handleProfileReset = () => {
                   className="help-button"
                   onClick={() => setIsHelpVisible(true)}
                   title="Aide et informations"
+                  aria-label="Afficher l'aide"
                 >
                   ?
                 </button>

--- a/client/src/configurator.css
+++ b/client/src/configurator.css
@@ -200,3 +200,8 @@
   color: #fff;
   transform: scale(1.1);
 }
+
+.help-button:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add aria-label to help button
- highlight help button when focused via keyboard

## Testing
- `npm test` (fails: Invalid package.json)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ed61c9a08333a8ff1c8b4073b5d6