### PR TITLE
Add streak badge component for quiz progress

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,7 @@ const EndScreen = lazy(() => import('./components/EndScreen'));
 import Spinner from './components/Spinner';
 import HelpModal from './components/HelpModal';
 import ProfileModal from './components/ProfileModal';
+import StreakBadge from './components/StreakBadge';
 import titleImage from './assets/inaturamouche-title.png';
 
 // --- STYLES ---
@@ -305,10 +306,11 @@ const handleProfileReset = () => {
             Mon Profil
           </button>
       </nav>
+      {isGameActive && <StreakBadge streak={currentStreak} />}
       <header className="app-header">
-       <img 
-          src={titleImage} 
-          alt="Titre Inaturamouche" 
+       <img
+          src={titleImage}
+          alt="Titre Inaturamouche"
           className={`app-title-image ${isGameActive || isGameOver ? 'clickable' : ''}`}
           onClick={isGameActive || isGameOver ? returnToConfig : undefined}
           title={isGameActive || isGameOver ? 'Retour au menu principal' : ''}

--- a/client/src/components/StreakBadge.css
+++ b/client/src/components/StreakBadge.css
@@ -1,0 +1,14 @@
+.streak-badge {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 9999px;
+  background-color: var(--accent-color);
+  color: var(--bg-color);
+  font-weight: 700;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+}

--- a/client/src/components/StreakBadge.jsx
+++ b/client/src/components/StreakBadge.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import './StreakBadge.css';
+
+const StreakBadge = ({ streak }) => {
+  if (streak <= 0) return null;
+
+  return (
+    <div className="streak-badge" aria-label={`S\u00e9rie de ${streak} bonnes r\u00e9ponses`}>
+      <span className="streak-icon" role="img" aria-hidden="true">🔥</span>
+      <span className="streak-count">{streak}</span>
+    </div>
+  );
+};
+
+export default StreakBadge;


### PR DESCRIPTION
## Summary
- add StreakBadge component to display current streak
- hook badge into App and use current streak state
- style badge with accent color

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8efc96fc48333b621d9eed3e621ed