### PR TITLE
fix: ensure choice buttons meet minimum height

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -117,6 +117,7 @@ button:focus-visible {
 }
 
 /* Boutons de choix dans le jeu */
+.choices button { min-height: 44px; }
 .choices button.correct, .choices button.correct:hover { background-color: var(--success-color); border-color: var(--success-color); color: #fff; }
 .choices button.incorrect, .choices button.incorrect:hover { background-color: var(--error-color); border-color: var(--error-color); color: #fff; }
 .choices button.disabled, .choices button.disabled:hover { opacity: 0.6; cursor: not-allowed; }


### PR DESCRIPTION
## Summary
- ensure quiz choice buttons have a minimum height for accessibility

## Testing
- `npm test` *(fails: package.json parse error)*
- `npm run lint`
- `npm run build` *(fails: package.json trailing comma)*

------
https://chatgpt.com/codex/tasks/task_e_68a8efd032688333b6941191a969daa4