### PR TITLE
Handle 404/500 errors in quiz fetch

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -115,7 +115,11 @@ const handleProfileReset = () => {
       }
     } catch (err) {
       if (!prefetchOnly) {
-        setError(err.message);
+        if (err.status === 404 || err.status === 500) {
+          setError('Aucune espèce trouvée, élargissez la recherche');
+        } else {
+          setError(err.message);
+        }
         setIsGameActive(false);
         setIsGameOver(false);
       }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,6 +1,6 @@
 // src/services/api.js
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+const API_BASE_URL = import.meta?.env?.VITE_API_URL || 'http://localhost:3001';
 
 async function apiGet(path, params = {}) {
   const url = new URL(path, API_BASE_URL);
@@ -9,7 +9,9 @@ async function apiGet(path, params = {}) {
   const res = await fetch(url);
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
-    throw new Error(data.error || 'Erreur réseau');
+    const error = new Error(data.error || 'Erreur réseau');
+    error.status = res.status;
+    throw error;
   }
   return data;
 }


### PR DESCRIPTION
## Summary
- Propagate HTTP status from API calls
- Show "Aucune espèce trouvée, élargissez la recherche" on 404/500 in quiz fetch

## Testing
- `node --input-type=module - <<'NODE'
import { fetchQuizQuestion } from './client/src/services/api.js';

async function simulate(status) {
  global.fetch = async () => new Response(JSON.stringify({ error: 'Not Found' }), { status });
  let errorMsg;
  const setError = (msg) => { errorMsg = msg; };
  const setIsGameActive = () => {};
  const setIsGameOver = () => {};
  const setLoading = () => {};
  const fetchQuestion = async (prefetchOnly = false) => {
    if (!prefetchOnly) {
      setLoading(true);
      setError(null);
    }
    try {
      const questionData = await fetchQuizQuestion(new URLSearchParams());
      if (prefetchOnly) {
      } else {
      }
    } catch (err) {
      if (!prefetchOnly) {
        if (err.status === 404 || err.status === 500) {
          setError('Aucune espèce trouvée, élargissez la recherche');
        } else {
          setError(err.message);
        }
        setIsGameActive(false);
        setIsGameOver(false);
      }
    } finally {
      if (!prefetchOnly) {
        setLoading(false);
      }
    }
  };
  await fetchQuestion();
  console.log('status', status, '=>', errorMsg);
}

await simulate(404);
await simulate(500);
NODE`
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8efbc52b88333bcdbcba549ec8ccb