### PR TITLE
fix: correct package.json dependencies syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "helmet": "^7.0.0",
+    "helmet": "^7.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"


### PR DESCRIPTION
## Summary
- remove trailing comma after `helmet` in root `package.json`

## Testing
- `npm run build` *(fails: Missing script: "build")*
- `cd client && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8f16d2cf883338bceaa5ec7a6e92a