### PR TITLE
Allow any origin when CORS whitelist missing

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,17 +17,23 @@ app.use(compression());
 // Les packs sont maintenant partagés avec le client.
 
 const allowedOrigins = process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : [];
-const corsOptions = {
-  origin: function (origin, callback) {
-    // Permet les requêtes sans origine (ex: Postman, apps mobiles) ou si l'origine est dans la liste blanche
-    if (!origin || allowedOrigins.indexOf(origin) !== -1) {
-      callback(null, true)
-    } else {
-      callback(new Error('Not allowed by CORS'))
+
+if (allowedOrigins.length > 0) {
+  const corsOptions = {
+    origin: function (origin, callback) {
+      // Permet les requêtes sans origine (ex: Postman, apps mobiles) ou si l'origine est dans la liste blanche
+      if (!origin || allowedOrigins.indexOf(origin) !== -1) {
+        callback(null, true)
+      } else {
+        callback(new Error('Not allowed by CORS'))
+      }
     }
-  }
-};
-app.use(cors(corsOptions));
+  };
+  app.use(cors(corsOptions));
+} else {
+  // Autorise toutes les origines lorsque aucune liste blanche n'est spécifiée
+  app.use(cors());
+}
 
 // Gestion du cache pour toutes les réponses
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- Allow all origins when `CORS_ORIGINS` env var is unset

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fb97efc883338efef79d90b5fbe4