### PR TITLE
feat: add API URL fallbacks

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,7 +1,10 @@
 // src/services/api.js
 
 const API_BASE_URL =
-  import.meta?.env?.VITE_API_URL || 'https://inaturamouche-api.onrender.com';
+  import.meta.env.VITE_API_URL ||
+  (import.meta.env.DEV
+    ? 'http://localhost:3001'
+    : 'https://inaturamouche.onrender.com');
 
 async function apiGet(path, params = {}) {
   const url = new URL(path, API_BASE_URL);


### PR DESCRIPTION
## Summary
- read API base URL from Vite env var
- default to localhost in development or Render in production

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a906ed945c83339d95c9331d7f0eda