### PR TITLE
Configure CORS allowed origins

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,25 +15,19 @@ app.use(helmet());
 app.use(compression());
 
 // Les packs sont maintenant partagés avec le client.
+const allowedOrigins = ['http://localhost:5173', 'https://inaturamouche.netlify.app'];
 
-const allowedOrigins = process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : [];
-
-if (allowedOrigins.length > 0) {
-  const corsOptions = {
-    origin: function (origin, callback) {
-      // Permet les requêtes sans origine (ex: Postman, apps mobiles) ou si l'origine est dans la liste blanche
-      if (!origin || allowedOrigins.indexOf(origin) !== -1) {
-        callback(null, true)
-      } else {
-        callback(new Error('Not allowed by CORS'))
-      }
-    }
-  };
-  app.use(cors(corsOptions));
-} else {
-  // Autorise toutes les origines lorsque aucune liste blanche n'est spécifiée
-  app.use(cors());
-}
+app.use(
+  cors({
+    origin: (o, cb) =>
+      allowedOrigins.includes(o) || !o ? cb(null, true) : cb(new Error()),
+  })
+);
+app.options('*', cors());
+app.use((req, res, next) => {
+  res.header('Vary', 'Origin');
+  next();
+});
 
 // Gestion du cache pour toutes les réponses
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- Replace env-based CORS config with explicit allowed origins for localhost and Netlify
- Add dynamic origin check, preflight handling, and Vary header

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -i -X OPTIONS -H "Origin:https://inaturamouche.netlify.app" -H "Access-Control-Request-Method:GET" https://inaturamouche.onrender.com/api/quiz-question` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a906f19d10833387f21482f4a0fa28