### PR TITLE
chore: add build script for client

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "build": "npm --prefix client run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add root build script to run client build

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a908de97308333964532505a81bc86