### PR TITLE
Install client dev dependencies before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "build": "npm --prefix client run build"
+    "build": "npm --prefix client install --include=dev && npm --prefix client run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- install client dev dependencies before running the client build to avoid missing vite during deployment

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a90ac7182c8333915490f41f21d1ab