### PR TITLE
Add tooltips for game modes and pack selector

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -376,14 +376,14 @@ const handleProfileReset = () => {
                       <button
                         onClick={() => setGameMode('easy')}
                         className={gameMode === 'easy' ? 'active' : ''}
-                        title="Mode facile : choix multiple"
+                        title="Mode facile : quatre propositions et indice facultatif"
                       >
                         Facile
                       </button>
                       <button
                         onClick={() => setGameMode('hard')}
                         className={gameMode === 'hard' ? 'active' : ''}
-                        title="Mode difficile : réponse libre"
+                        title="Mode difficile : devinez la taxonomie avec essais limités"
                       >
                         Difficile
                       </button>

--- a/client/src/Configurator.jsx
+++ b/client/src/Configurator.jsx
@@ -20,8 +20,14 @@ function Configurator({ onStartGame, onStartReview, hasMissedSpecies, error, act
       <div className="pack-selector">
         {/* --- MODIFICATION ICI --- */}
         {/* On remplace les boutons par un menu déroulant */}
-        <label htmlFor="pack-select">Choisissez un pack de jeu :</label>
-        <select id="pack-select" value={activePackId} onChange={handlePackChange} className="pack-select-dropdown">
+          <label htmlFor="pack-select">Choisissez un pack de jeu :</label>
+          <select
+            id="pack-select"
+            value={activePackId}
+            onChange={handlePackChange}
+            className="pack-select-dropdown"
+            title="Sélectionnez un pack thématique ou personnalisez votre partie"
+          >
           {PACKS.map(pack => (
             <option key={pack.id} value={pack.id}>
               {pack.title}


### PR DESCRIPTION
## Summary
- Improve game mode buttons with explanatory tooltips
- Clarify pack selection via hover tooltip on dropdown

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9b86ac974833391ccb7fe33c6d7de