### PR TITLE
feat: display streak bonus in round recap

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -143,6 +143,7 @@ button:focus-visible {
 /* --- AUTRES STYLES (inchangés ou mineurs) --- */
 .game-screen .card { flex-grow: 1; }
 .game-header { width: 100%; display: flex; justify-content: space-between; align-items: center; font-size: 1.1rem; font-weight: 600; flex-shrink: 0; }
+.score-container { display: flex; align-items: center; gap: 0.5rem; }
 .score { color: var(--accent-color); font-weight: 700; }
 .game-main { display: flex; flex-direction: column; gap: 1rem; width: 100%; flex-grow: 1; }
 .image-section { display: flex; flex-direction: column; gap: 0.75rem; }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,7 +18,6 @@ const EndScreen = lazy(() => import('./components/EndScreen'));
 import Spinner from './components/Spinner';
 import HelpModal from './components/HelpModal';
 import ProfileModal from './components/ProfileModal';
-import StreakBadge from './components/StreakBadge';
 import titleImage from './assets/inaturamouche-title.png';
 
 // --- STYLES ---
@@ -316,7 +315,6 @@ const handleProfileReset = () => {
             Mon Profil
           </button>
       </nav>
-      {isGameActive && <StreakBadge streak={currentStreak} />}
       <header className="app-header">
        <img
           src={titleImage}
@@ -340,6 +338,7 @@ const handleProfileReset = () => {
                       onAnswer={handleNextQuestion}
                       onUpdateScore={updateScore}
                       nextImageUrl={nextImageUrl}
+                      currentStreak={currentStreak}
                     />
                   : <HardMode
                       question={question}
@@ -347,6 +346,7 @@ const handleProfileReset = () => {
                       onNextQuestion={handleNextQuestion}
                       onQuit={returnToConfig}
                       nextImageUrl={nextImageUrl}
+                      currentStreak={currentStreak}
                     />
               )
           ) : isGameOver ? (

--- a/client/src/HardMode.css
+++ b/client/src/HardMode.css
@@ -112,14 +112,17 @@
   .hard-mode-stats {
     width: 100%;
     max-width: 400px;
-    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
     font-size: 1.1rem;
     font-weight: 600;
     color: var(--accent-color);
     padding: var(--space-3);
-  background-color: rgba(0,0,0,0.2);
-  border-radius: 8px;
-}
+    background-color: rgba(0,0,0,0.2);
+    border-radius: 8px;
+  }
 
 .hard-mode-actions {
   display: grid;

--- a/client/src/HardMode.jsx
+++ b/client/src/HardMode.jsx
@@ -7,6 +7,7 @@ import RoundSummaryModal from './components/RoundSummaryModal';
 import './HardMode.css';
 import { getTaxonDetails } from './services/api'; // NOUVEL IMPORT
 import { computeScore } from './utils/scoring';
+import StreakBadge from './components/StreakBadge';
 
 
 const RANKS = ['kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'];
@@ -23,7 +24,7 @@ const SCORE_PER_RANK = {
   species: 40,
 };
 
-function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
+function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl, currentStreak }) {
   const [knownTaxa, setKnownTaxa] = useState({});
   const [guesses, setGuesses] = useState(INITIAL_GUESSES);
   const [currentScore, setCurrentScore] = useState(score);
@@ -90,7 +91,8 @@ function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
           guessesRemaining: newGuessesCount,
           isCorrect: true
         });
-        setScoreInfo({ points, bonus });
+        const streakBonus = 2 * (currentStreak + 1);
+        setScoreInfo({ points, bonus, streakBonus });
         setRoundStatus('win');
         return; // On arrête la fonction ici, c'est gagné.
       }
@@ -103,7 +105,7 @@ function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
           guessesRemaining: newGuessesCount,
           isCorrect: false
         });
-        setScoreInfo({ points, bonus });
+        setScoreInfo({ points, bonus, streakBonus: 0 });
         setRoundStatus('lose');
         return; // On arrête la fonction, c'est perdu.
       }
@@ -130,7 +132,7 @@ function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
           guessesRemaining: newGuessesCount,
           isCorrect: false
         });
-        setScoreInfo({ points, bonus });
+        setScoreInfo({ points, bonus, streakBonus: 0 });
         setRoundStatus('lose');
       }
     }
@@ -140,6 +142,7 @@ function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
     const result = {
       points: scoreInfo?.points || 0,
       bonus: scoreInfo?.bonus || 0,
+      streakBonus: scoreInfo?.streakBonus || 0,
       isCorrect: roundStatus === 'win'
     };
     onNextQuestion(result);
@@ -182,7 +185,8 @@ function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
             guessesRemaining: newGuessesCount,
             isCorrect: true
           });
-          setScoreInfo({ points, bonus });
+          const streakBonus = 2 * (currentStreak + 1);
+          setScoreInfo({ points, bonus, streakBonus });
           setRoundStatus('win');
           return; // La partie est gagnée, on arrête tout
         }
@@ -195,7 +199,7 @@ function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
             guessesRemaining: newGuessesCount,
             isCorrect: false
           });
-          setScoreInfo({ points, bonus });
+          setScoreInfo({ points, bonus, streakBonus: 0 });
           setRoundStatus('lose');
         }
       }
@@ -250,7 +254,10 @@ function HardMode({ question, score, onNextQuestion, onQuit, nextImageUrl }) {
           {feedbackMessage && (
             <div className="feedback-bar" aria-live="polite">{feedbackMessage}</div>
           )}
-          <div className="hard-mode-stats">Chances : {guesses} | Score : {currentScore}</div>
+          <div className="hard-mode-stats">
+            <span>Chances : {guesses} | Score : {currentScore}</span>
+            <StreakBadge streak={currentStreak} />
+          </div>
           
           {/* MODIFIÉ: Grille d'actions pour inclure les nouveaux indices */}
           <div className="hard-mode-actions">

--- a/client/src/components/Easymode.jsx
+++ b/client/src/components/Easymode.jsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react';
 import ImageViewer from './ImageViewer';
 import RoundSummaryModal from './RoundSummaryModal';
 import { computeScore } from '../utils/scoring';
+import StreakBadge from './StreakBadge';
 
 const MAX_QUESTIONS_PER_GAME = 5;
 const HINT_COST_EASY = 5; // Pénalité de 5 points pour utiliser l'indice
 
 // MODIFIÉ: Ajout de onUpdateScore pour la pénalité de l'indice
-const EasyMode = ({ question, score, questionCount, onAnswer, onUpdateScore, nextImageUrl }) => {
+// et currentStreak pour calculer le bonus de série
+const EasyMode = ({ question, score, questionCount, onAnswer, onUpdateScore, nextImageUrl, currentStreak }) => {
   const [answerStatus, setAnswerStatus] = useState({ answered: false, correctAnswer: '', selectedAnswer: '' });
   const [showSummary, setShowSummary] = useState(false);
   
@@ -54,7 +56,8 @@ const EasyMode = ({ question, score, questionCount, onAnswer, onUpdateScore, nex
   };
 
   const isCorrectAnswer = answerStatus.selectedAnswer === answerStatus.correctAnswer;
-  const scoreInfo = computeScore({ mode: 'easy', isCorrect: isCorrectAnswer });
+  const streakBonus = isCorrectAnswer ? 2 * (currentStreak + 1) : 0;
+  const scoreInfo = { ...computeScore({ mode: 'easy', isCorrect: isCorrectAnswer }), streakBonus };
 
   return (
     <>
@@ -81,7 +84,10 @@ const EasyMode = ({ question, score, questionCount, onAnswer, onUpdateScore, nex
                 Indice (-{HINT_COST_EASY} pts)
               </button>
             </div>
-            <h2 className="score">Score: {score}</h2>
+            <div className="score-container">
+              <h2 className="score">Score: {score}</h2>
+              <StreakBadge streak={currentStreak} />
+            </div>
           </header>
           <main className="game-main">
             <div className="image-section">

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -88,7 +88,10 @@ const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
             {scoreInfo.bonus > 0 && (
               <p>Bonus : <span className="score-points">+{scoreInfo.bonus}</span></p>
             )}
-            <p>Total pour la manche : <span className="score-total">+{scoreInfo.points + (scoreInfo.bonus || 0)}</span></p>
+            {scoreInfo.streakBonus > 0 && (
+              <p>Bonus de série : <span className="score-points">+{scoreInfo.streakBonus}</span></p>
+            )}
+            <p>Total pour la manche : <span className="score-total">+{scoreInfo.points + (scoreInfo.bonus || 0) + (scoreInfo.streakBonus || 0)}</span></p>
           </div>
         )}
         

--- a/client/src/components/StreakBadge.css
+++ b/client/src/components/StreakBadge.css
@@ -1,8 +1,5 @@
 .streak-badge {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.25rem;
   padding: 0.4rem 0.8rem;


### PR DESCRIPTION
## Summary
- show current streak during gameplay
- calculate streak bonus in easy and hard modes
- display streak bonus and total in round summary
- place streak badge next to chances and score

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9b683862c833395b5b4b823b4de3d