### PR TITLE
feat: show modals for errors and achievements

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -150,7 +150,6 @@ button:focus-visible {
 .choices { width: 100%; display: grid; grid-template-columns: 1fr; gap: 0.75rem; flex-shrink: 0; margin-top: auto; }
   .inat-link { display: inline-flex; align-self: center; gap: 8px; padding: var(--space-2) calc(var(--space-2) + var(--space-1)); background-color: rgba(0, 0, 0, 0.2); border-radius: 8px; color: var(--text-color-muted); text-decoration: none; font-size: 0.9rem; font-weight: 500; transition: all 0.2s; }
 .inat-link:hover { background-color: var(--primary-color); color: var(--text-color); }
-  .error-message { color: #fff; background-color: var(--error-color); padding: var(--space-3); border-radius: var(--border-radius); width: 100%; max-width: 800px; box-sizing: border-box; font-weight: 500; text-align: center; margin-bottom: var(--space-3); }
 .end-screen .card { text-align: center; }
 .end-screen .species-list {
   list-style: none;
@@ -214,38 +213,6 @@ button:focus-visible {
   background-color: var(--bg-color);
 }
 
-  .achievement-toast {
-      position: fixed;
-      bottom: 20px;
-      left: 50%;
-      transform: translateX(-50%);
-      background-color: var(--accent-color);
-      color: var(--bg-color);
-      padding: var(--space-3) var(--space-4);
-      border-radius: var(--border-radius);
-      box-shadow: 0 4px 15px rgba(0,0,0,0.4);
-      z-index: 2000;
-      text-align: center;
-      font-weight: 600;
-      animation: toast-in 0.5s ease-out forwards;
-  }
-
-  .achievement-toast p {
-      margin: var(--space-1) 0 0 0;
-      font-size: 0.9rem;
-      font-weight: 500;
-  }
-
-@keyframes toast-in {
-    from {
-        bottom: -100px;
-        opacity: 0;
-    }
-    to {
-        bottom: 20px;
-        opacity: 1;
-    }
-}
 
   .hint-button-easy {
     padding: 6px calc(var(--space-2) + var(--space-1));

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,7 +6,7 @@ import React, { useState, useEffect, useCallback, useReducer, lazy, Suspense } f
 import PACKS from '../../shared/packs.js';
 import { initialCustomFilters, customFilterReducer } from './state/filterReducer';
 import { loadProfileWithDefaults, saveProfile } from './services/PlayerProfile';
-import { checkNewAchievements, ACHIEVEMENTS } from './achievements';
+import { checkNewAchievements } from './achievements';
 import { fetchQuizQuestion } from './services/api'; // NOUVEL IMPORT
 
 
@@ -18,6 +18,7 @@ const EndScreen = lazy(() => import('./components/EndScreen'));
 import Spinner from './components/Spinner';
 import HelpModal from './components/HelpModal';
 import ProfileModal from './components/ProfileModal';
+import AchievementModal from './components/AchievementModal';
 import titleImage from './assets/inaturamouche-title.png';
 
 // --- STYLES ---
@@ -303,10 +304,10 @@ const handleProfileReset = () => {
       {isHelpVisible && <HelpModal onClose={handleCloseHelp} />}
       
       {newlyUnlocked.length > 0 && (
-        <div className="achievement-toast">
-          🏆 Succès Débloqué !
-          <p>{ACHIEVEMENTS[newlyUnlocked[0]].title}</p>
-        </div>
+        <AchievementModal
+          achievementId={newlyUnlocked[0]}
+          onClose={() => setNewlyUnlocked([])}
+        />
       )}
       <nav className="main-nav">
           <button onClick={() => {
@@ -391,6 +392,7 @@ const handleProfileReset = () => {
                   onStartReview={() => startGame(true)}
                   hasMissedSpecies={(playerProfile?.stats?.missedSpecies?.length || 0) > 0}
                   error={error}
+                  setError={setError}
                   activePackId={activePackId}
                   setActivePackId={setActivePackId}
                   customFilters={customFilters}

--- a/client/src/Configurator.jsx
+++ b/client/src/Configurator.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PACKS from '../../shared/packs.js';
 import CustomFilter from './CustomFilter';
+import ErrorModal from './components/ErrorModal';
 
-function Configurator({ onStartGame, onStartReview, hasMissedSpecies, error, activePackId, setActivePackId, customFilters, dispatch }) {
+function Configurator({ onStartGame, onStartReview, hasMissedSpecies, error, setError, activePackId, setActivePackId, customFilters, dispatch }) {
 
   // On trouve les détails du pack actuellement sélectionné pour afficher sa description
 
@@ -14,7 +15,7 @@ function Configurator({ onStartGame, onStartReview, hasMissedSpecies, error, act
   return (
     <div>
       {error && (
-        <p className="error-message" aria-live="assertive">Erreur : {error}</p>
+        <ErrorModal message={error} onClose={() => setError(null)} />
       )}
       
       <div className="pack-selector">

--- a/client/src/components/AchievementModal.jsx
+++ b/client/src/components/AchievementModal.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Modal from './Modal';
+import { ACHIEVEMENTS } from '../achievements';
+
+function AchievementModal({ achievementId, onClose }) {
+  const achievement = ACHIEVEMENTS[achievementId];
+  return (
+    <Modal onClose={onClose}>
+      <div className="achievement-modal">
+        <h2 className="modal-title">🏆 Succès débloqué !</h2>
+        <p>{achievement.title}</p>
+      </div>
+    </Modal>
+  );
+}
+
+export default AchievementModal;

--- a/client/src/components/ErrorModal.jsx
+++ b/client/src/components/ErrorModal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Modal from './Modal';
+
+function ErrorModal({ message, onClose }) {
+  return (
+    <Modal onClose={onClose}>
+      <div className="error-modal">
+        <h2 className="modal-title">Erreur</h2>
+        <p>{message}</p>
+      </div>
+    </Modal>
+  );
+}
+
+export default ErrorModal;

--- a/client/src/components/Modal.css
+++ b/client/src/components/Modal.css
@@ -1,0 +1,61 @@
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fade-in 0.3s ease;
+}
+
+.modal-content {
+  background-color: var(--surface-color);
+  padding: var(--space-5);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  width: 90%;
+  max-width: 550px;
+  border: 1px solid var(--border-color);
+  position: relative;
+  animation: slide-up 0.4s ease-out;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from { transform: translateY(30px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.close-button {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: transparent;
+  border: none;
+  font-size: 2rem;
+  color: var(--text-color-muted);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.modal-title {
+  text-align: center;
+  margin: 0 0 var(--space-4) 0;
+}
+
+.error-modal .modal-title {
+  color: var(--error-color);
+}
+
+.achievement-modal .modal-title {
+  color: var(--accent-color);
+}

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import './Modal.css';
+
+function Modal({ onClose, children }) {
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal-content" tabIndex="-1" onClick={(e) => e.stopPropagation()}>
+        <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default Modal;


### PR DESCRIPTION
## Summary
- Add reusable modal component with fade and slide animations
- Display errors in a modal using the new ErrorModal
- Replace achievement toast with animated AchievementModal

## Testing
- `npm test` *(fails: Missing script "test" in client)*
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Missing script "lint" in root)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ba5e99388333901c9d52b2f664c3