### PR TITLE
Show review button only when enough missed species

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -392,7 +392,7 @@ const handleProfileReset = () => {
                 <Configurator
                   onStartGame={() => startGame(false)}
                   onStartReview={() => startGame(true)}
-                  hasMissedSpecies={(playerProfile?.stats?.missedSpecies?.length || 0) > 0}
+                  canStartReview={(playerProfile?.stats?.missedSpecies?.length || 0) >= MAX_QUESTIONS_PER_GAME}
                   error={error}
                   setError={setError}
                   activePackId={activePackId}

--- a/client/src/Configurator.jsx
+++ b/client/src/Configurator.jsx
@@ -3,7 +3,7 @@ import PACKS from '../../shared/packs.js';
 import CustomFilter from './CustomFilter';
 import ErrorModal from './components/ErrorModal';
 
-function Configurator({ onStartGame, onStartReview, hasMissedSpecies, error, setError, activePackId, setActivePackId, customFilters, dispatch }) {
+function Configurator({ onStartGame, onStartReview, canStartReview, error, setError, activePackId, setActivePackId, customFilters, dispatch }) {
 
   // On trouve les détails du pack actuellement sélectionné pour afficher sa description
 
@@ -52,7 +52,7 @@ function Configurator({ onStartGame, onStartReview, hasMissedSpecies, error, set
       </div>
 
       <button onClick={onStartGame} className="start-button">Lancer la partie !</button>
-      {hasMissedSpecies && (
+      {canStartReview && (
         <button onClick={onStartReview} className="start-button">Réviser mes erreurs</button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Only display the "Réviser mes erreurs" button when player has at least five missed species to review
- Pass a `canStartReview` flag from `App` to `Configurator`

## Testing
- `npm test` (fails: Error: no test specified)
- `cd client && npm test` (fails: Missing script: "test")
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9c0f20f4c83339ca7fd830c818d98