### PR TITLE
Refine end-game UI and hint feedback

### DIFF
--- a/client/src/HardMode.css
+++ b/client/src/HardMode.css
@@ -228,21 +228,23 @@
 }
 
   .feedback-bar {
-    width: 100%;
-    max-width: 400px;
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
     padding: calc(var(--space-2) + var(--space-1)) var(--space-3);
     border-radius: 8px;
     text-align: center;
     font-weight: 500;
     color: #fff;
     background-color: var(--primary-color);
-    margin-bottom: calc(var(--space-2) * -1); /* Se place joliment entre les stats et les boutons */
+    z-index: 1000;
     animation: fade-in-down 0.5s ease;
   }
 
 @keyframes fade-in-down {
-  from { opacity: 0; transform: translateY(-10px); }
-  to { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; transform: translate(-50%, 10px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
 }
 
 /* --- Amélioration Visuelle pour Taxon Connu --- */

--- a/client/src/components/RoundSummaryModal.css
+++ b/client/src/components/RoundSummaryModal.css
@@ -45,14 +45,6 @@
   to { transform: translateY(0); opacity: 1; }
 }
 
-.summary-modal h2 {
-  margin: 0;
-  /* MODIFIÉ: Taille de la police du titre réduite */
-  font-size: 1.6rem;
-}
-
-.win-title { color: var(--success-color); }
-.lose-title { color: var(--error-color); }
 
   .correct-answer-section {
     background-color: var(--bg-color);

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef } from 'react';
 import './RoundSummaryModal.css';
 import { getSizedImageUrl } from '../utils/imageUtils';
 
-const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
+const RoundSummaryModal = ({ question, scoreInfo, onNext }) => {
   const buttonRef = useRef(null);
   const previousActiveRef = useRef(null);
 
@@ -33,7 +33,6 @@ const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
   }
 
   const { bonne_reponse, inaturalist_url } = question;
-  const isWin = status === 'win';
 
   // --- LA SEULE LIGNE À CHANGER EST CI-DESSOUS ---
   const commonName = bonne_reponse.common_name; // On lit `common_name` au lieu de `preferred_common_name`
@@ -48,10 +47,6 @@ const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
   return (
     <div className="modal-backdrop">
       <div className="modal-content summary-modal" role="dialog" aria-modal="true">
-        <h2 className={isWin ? 'win-title' : 'lose-title'}>
-          {isWin ? '🎉 Espèce trouvée !' : '😟 Dommage !'}
-        </h2>
-        
         <div className="correct-answer-section">
           <p>La réponse était :</p>
           <img


### PR DESCRIPTION
## Summary
- Remove victory/defeat heading from the round summary modal.
- Display feedback, including hint usage, as a temporary fixed popup at the bottom of the screen.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9c353d3788333a53f6fc08f866af8