### PR TITLE
Ajout des attributs ARIA sur les modales

### DIFF
--- a/client/src/components/HelpModal.jsx
+++ b/client/src/components/HelpModal.jsx
@@ -21,7 +21,7 @@ function HelpModal({ onClose }) {
 
   return (
     // Le fond assombri qui ferme le modal au clic
-    <div className="modal-backdrop" onClick={onClose}>
+    <div className="modal-backdrop" onClick={onClose} role="dialog" aria-modal="true">
       {/* On empêche la propagation du clic pour que le modal ne se ferme pas quand on clique dessus */}
       <div className="modal-content" tabIndex="-1" onClick={(e) => e.stopPropagation()}>
         <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -13,7 +13,7 @@ function Modal({ onClose, children }) {
   }, [onClose]);
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <div className="modal-backdrop" onClick={onClose} role="dialog" aria-modal="true">
       <div className="modal-content" tabIndex="-1" onClick={(e) => e.stopPropagation()}>
         <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>
         {children}

--- a/client/src/components/ProfileModal.jsx
+++ b/client/src/components/ProfileModal.jsx
@@ -95,7 +95,7 @@ function ProfileModal({ profile, onClose, onResetProfile }) {
   const hardAccuracy = ((profile.stats.accuracyHard || 0) * 100).toFixed(1);
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <div className="modal-backdrop" onClick={onClose} role="dialog" aria-modal="true">
       <div className="modal-content profile-modal" onClick={(e) => e.stopPropagation()}>
         <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>
         <h2 className="modal-title">Profil du Joueur</h2>

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -45,8 +45,8 @@ const RoundSummaryModal = ({ question, scoreInfo, onNext }) => {
   const displayCommonName = commonName && commonName !== scientificName ? commonName : null;
 
   return (
-    <div className="modal-backdrop">
-      <div className="modal-content summary-modal" role="dialog" aria-modal="true">
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal-content summary-modal">
         <div className="correct-answer-section">
           <p>La réponse était :</p>
           <img


### PR DESCRIPTION
## Summary
- ajoute `role="dialog"` et `aria-modal="true"` aux backdrops des modales
- simplifie la déclaration des modales en retirant les attributs doublons

## Testing
- `npm test` *(échoue : no test specified)*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9c6dbada4833384b25b3d2dbd72f6