### PR TITLE
feat: add PWA metadata and Apple icon

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,6 +14,13 @@
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#283618" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="Inaturamouche" />
+
     </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add manifest and theme color metadata for PWA
- include Apple touch icon and iOS web app tags

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9c70560088333a1e015eb7b067eec