### PR TITLE
feat: improve image loading

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -323,6 +323,8 @@ const handleProfileReset = () => {
           className={`app-title-image ${isGameActive || isGameOver ? 'clickable' : ''}`}
           onClick={isGameActive || isGameOver ? returnToConfig : undefined}
           title={isGameActive || isGameOver ? 'Retour au menu principal' : ''}
+          decoding="async"
+          fetchpriority="high"
         />
       </header>
       

--- a/client/src/components/ImageViewer.css
+++ b/client/src/components/ImageViewer.css
@@ -25,7 +25,7 @@
 
 .image-wrapper img {
   width: 100%;
-  height: 100%;
+  height: auto;
   object-fit: contain; /* Affiche l'image entièrement sans la déformer */
   user-select: none; /* Empêche la sélection de l'image */
   -webkit-user-drag: none; /* Empêche le glisser-déposer natif */

--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -12,6 +12,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
   const [scale, setScale] = useState(1);     // Niveau de zoom courant
   const [transform, setTransform] = useState({ x: 0, y: 0 }); // Position de l'image lors du déplacement (pan)
   const [isLoaded, setIsLoaded] = useState(true); // État de chargement de l'image
+  const [aspectRatio, setAspectRatio] = useState(); // Ratio naturel de l'image
 
   // --- Références pour la gestion du déplacement ---
   const containerRef = useRef(null); // Référence au conteneur pour gérer le style du curseur
@@ -165,6 +166,14 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
     endPointer(e);
   };
 
+  const handleImageLoad = (e) => {
+    setIsLoaded(true);
+    const { naturalWidth, naturalHeight } = e.target;
+    if (naturalWidth && naturalHeight) {
+      setAspectRatio(`${naturalWidth} / ${naturalHeight}`);
+    }
+  };
+
   // Si pas d'images, on n'affiche rien.
   if (!imageUrls || imageUrls.length === 0) {
     return <div className="image-viewer-container">Chargement...</div>;
@@ -190,8 +199,10 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
           loading="lazy"
           decoding={currentIndex === 0 ? 'async' : undefined}
           fetchpriority={currentIndex === 0 ? 'high' : undefined}
-          onLoad={() => setIsLoaded(true)}
+          onLoad={handleImageLoad}
           style={{
+            width: '100%',
+            aspectRatio,
             transform: `translateX(${transform.x}px) translateY(${transform.y}px) scale(${scale}) rotate(${rotation}deg)`,
             transition:
               isPanning.current || initialPinchDistance.current

--- a/client/src/components/RoundSummaryModal.css
+++ b/client/src/components/RoundSummaryModal.css
@@ -55,13 +55,13 @@
 
   .answer-image {
     width: 100%;
-    /* MODIFIÉ: Hauteur de l'image significativement réduite */
-    height: 140px;
+    aspect-ratio: 4 / 3;
+    height: auto;
     object-fit: cover;
     border-radius: 8px;
     margin: var(--space-2) 0;
   border: 2px solid var(--border-color);
-}
+  }
 
   .answer-name {
     margin: var(--space-2) 0 var(--space-1) 0;

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -56,6 +56,9 @@ const RoundSummaryModal = ({ question, scoreInfo, onNext }) => {
             alt={commonName || scientificName}
             className="answer-image"
             loading="lazy"
+            decoding={imageUrl ? 'async' : undefined}
+            fetchpriority={imageUrl ? 'high' : undefined}
+            style={{ width: '100%', aspectRatio: '4 / 3' }}
           />
           
           {/* On affiche le nom commun que s'il existe ET est différent du nom scientifique */}


### PR DESCRIPTION
## Summary
- derive and apply natural aspect ratio to viewer images
- expand summary modal images with width 100% and lazy attributes
- mark title image as high priority for faster decode

## Testing
- `npm --prefix client run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c6cbb28483338ee2ae3b0127c6df