### PR TITLE
feat: support dynamic viewport height and reduced-motion

### DIFF
--- a/client/public/offline.html
+++ b/client/public/offline.html
@@ -5,7 +5,8 @@
     <title>Hors ligne</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-      body { display: flex; justify-content: center; align-items: center; min-height: 100vh; font-family: sans-serif; text-align: center; }
+      :root { --full-height: 100dvh; }
+      body { display: flex; justify-content: center; align-items: center; min-height: var(--full-height); font-family: sans-serif; text-align: center; }
     </style>
   </head>
   <body>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -20,7 +20,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  min-height: var(--full-height);
 }
 
 .app-header {

--- a/client/src/components/ProfileModal.css
+++ b/client/src/components/ProfileModal.css
@@ -4,7 +4,7 @@
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
+  min-height: var(--full-height);
   background-color: rgba(0, 0, 0, 0.7);
   display: flex;
   justify-content: center;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,13 +21,14 @@
   --space-3: 1rem;
   --space-4: 1.5rem;
   --space-5: 2rem;
+  --full-height: 100dvh;
 }
 
 /* --- STYLE DE BASE --- */
 html, body {
   margin: 0;
   padding: 0;
-  min-height: 100vh;
+  min-height: var(--full-height);
   width: 100%;
   font-family: var(--font-family-main);
   background-color: var(--bg-color);
@@ -72,4 +73,11 @@ button {
 :focus {
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
 }


### PR DESCRIPTION
## Summary
- use CSS token for full viewport height (100dvh)
- respect prefers-reduced-motion and disable animations

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix client test` (fails: Missing script)
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9c6ee0ecc83339b6a943aa3c5e86c