### PR TITLE
feat: cache robots file with VitePWA

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
         'apple-touch-icon.png',
         'assets/*.png',
         'offline.html',
+        'robots.txt',
         'packs/*.json'
       ],
       manifest: {


### PR DESCRIPTION
## Summary
- add `robots.txt` to public assets
- register `robots.txt` in VitePWA plugin for caching

## Testing
- `npm test` (fails: no test specified)
- `npm test` in `client` (fails: missing script)
- `npm run lint` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68a9c70ed5d8833391339a40c498c38f