### PR TITLE
fix: define isWin and add mobile web app meta

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -18,6 +18,7 @@
     <meta name="theme-color" content="#283618" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="Inaturamouche" />
 

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -35,6 +35,8 @@ const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
 
   const { bonne_reponse, inaturalist_url } = question;
 
+  const isWin = status === 'win';
+
   const commonName = bonne_reponse.common_name;
 
   const scientificName = bonne_reponse.name;


### PR DESCRIPTION
## Summary
- fix modal summary not defining `isWin` causing runtime error
- add `mobile-web-app-capable` meta tag for modern browsers

## Testing
- `npm test`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ce62867483338f987c1f8aea741a