### PR TITLE
fix: scope Configurator styles

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,10 +24,9 @@ import titleImage from './assets/inaturamouche-title.png';
 // --- STYLES ---
 import './App.css';
 import './HardMode.css';
-import './components/ImageViewer.css'; 
-import './configurator.css';
+import './components/ImageViewer.css';
 import './components/ProfileModal.css';
-import './components/HelpModal.css'; 
+import './components/HelpModal.css';
 
 const MAX_QUESTIONS_PER_GAME = 5;
 

--- a/client/src/Configurator.jsx
+++ b/client/src/Configurator.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PACKS from '../../shared/packs.js';
 import CustomFilter from './CustomFilter';
 import ErrorModal from './components/ErrorModal';
+import './configurator.css';
 
 function Configurator({ onStartGame, onStartReview, canStartReview, error, setError, activePackId, setActivePackId, customFilters, dispatch }) {
 


### PR DESCRIPTION
## Summary
- load Configurator component styles within the component itself
- clean up App imports to avoid relying on parent for Configurator styling

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9d01c0c588333921bbc95d5ced489