### PR TITLE
Refactor image viewer navigation

### DIFF
--- a/client/src/components/ImageViewer.css
+++ b/client/src/components/ImageViewer.css
@@ -4,7 +4,6 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem; /* Espace entre l'image et les contrôles */
 }
 
 /* Wrapper qui contient l'image, gère le fond et le clipping */
@@ -20,7 +19,6 @@
   align-items: center;
   justify-content: center;
   cursor: pointer; /* Indique qu'on peut cliquer pour zoomer */
-  touch-action: none; /* Permet de gérer le pan/zoom manuellement */
 }
 
 .image-wrapper img {
@@ -32,50 +30,60 @@
   transition: transform 0.3s cubic-bezier(0.25, 0.8, 0.25, 1); /* Animation douce */
 }
 
-/* Conteneur pour les boutons de contrôle */
-.image-controls {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
-  flex-shrink: 0; /* Empêche les contrôles de rétrécir */
-}
-
-/* Style commun pour les boutons de contrôle */
-.image-controls button {
-  background-color: var(--surface-color);
-  border: 1px solid var(--border-color);
-  color: var(--text-color);
+/* Boutons de navigation placés au-dessus de l'image */
+.nav-button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  border: none;
+  color: #fff;
   font-size: 1.2rem;
   font-weight: bold;
   cursor: pointer;
-  border-radius: 50%; /* Boutons ronds */
+  border-radius: 50%;
   width: 40px;
   height: 40px;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  line-height: 1;
-  transition: all 0.2s ease;
 }
 
-.image-controls button:hover:not(:disabled) {
-  background-color: var(--primary-color);
-  border-color: var(--primary-color);
+.nav-button.prev {
+  left: 10px;
 }
 
-.image-controls button:disabled {
+.nav-button.next {
+  right: 10px;
+}
+
+.nav-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-/* Style pour le compteur de page (ex: 1 / 3) */
-.image-controls span {
-  font-size: 1rem;
-  font-weight: 500;
-  color: var(--text-color-muted);
-  min-width: 50px;
-  text-align: center;
+/* Points de navigation */
+.dots {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.dot.active {
+  background-color: rgba(255, 255, 255, 0.9);
 }
 
 /* Placeholder skeleton affiché pendant le chargement des images */

--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -8,8 +8,7 @@ const MAX_ZOOM = 2.5;
 function ImageViewer({ imageUrls, alt, nextImageUrl }) {
   // --- États du composant ---
   const [currentIndex, setCurrentIndex] = useState(0); // Index de l'image affichée
-  const [rotation, setRotation] = useState(0);       // Angle de rotation de l'image
-  const [scale, setScale] = useState(1);     // Niveau de zoom courant
+  const [scale, setScale] = useState(1); // Niveau de zoom courant
   const [transform, setTransform] = useState({ x: 0, y: 0 }); // Position de l'image lors du déplacement (pan)
   const [isLoaded, setIsLoaded] = useState(true); // État de chargement de l'image
   const [aspectRatio, setAspectRatio] = useState(); // Ratio naturel de l'image
@@ -26,7 +25,6 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
   // --- Effet pour réinitialiser l'état quand les images changent (nouvelle question) ---
   useEffect(() => {
     setCurrentIndex(0);
-    setRotation(0);
     setScale(1);
     setTransform({ x: 0, y: 0 });
     setIsLoaded(true);
@@ -52,7 +50,6 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
 
   // --- Fonctions pour les contrôles ---
   const resetViewState = () => {
-    setRotation(0);
     setScale(1);
     setTransform({ x: 0, y: 0 });
   };
@@ -65,10 +62,6 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
   const handlePrev = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + imageUrls.length) % imageUrls.length);
     resetViewState();
-  };
-
-  const handleRotate = () => {
-    setRotation((prevRotation) => (prevRotation + 90) % 360);
   };
 
   // --- Fonctions pour le Zoom et le Déplacement (Pan) ---
@@ -184,6 +177,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
       <div
         ref={containerRef}
         className="image-wrapper"
+        style={{ touchAction: scale > 1 ? 'none' : 'pan-y' }}
         onClick={handleImageClick}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
@@ -203,7 +197,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
           style={{
             width: '100%',
             aspectRatio,
-            transform: `translateX(${transform.x}px) translateY(${transform.y}px) scale(${scale}) rotate(${rotation}deg)`,
+            transform: `translateX(${transform.x}px) translateY(${transform.y}px) scale(${scale})`,
             transition:
               isPanning.current || initialPinchDistance.current
                 ? 'none'
@@ -214,12 +208,41 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
         {!isLoaded && currentIndex !== 0 && (
           <div className="image-placeholder" />
         )}
-      </div>
-      <div className="image-controls">
-        <button onClick={handlePrev} disabled={imageUrls.length <= 1}>‹</button>
-        <span>{currentIndex + 1} / {imageUrls.length}</span>
-        <button onClick={handleNext} disabled={imageUrls.length <= 1}>›</button>
-        <button onClick={handleRotate} className="rotate-btn" title="Pivoter l'image">↻</button>
+        {imageUrls.length > 1 && (
+          <>
+            <button
+              className="nav-button prev"
+              onClick={(e) => {
+                e.stopPropagation();
+                handlePrev();
+              }}
+            >
+              ‹
+            </button>
+            <button
+              className="nav-button next"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleNext();
+              }}
+            >
+              ›
+            </button>
+            <div className="dots">
+              {imageUrls.map((_, idx) => (
+                <button
+                  key={idx}
+                  className={`dot ${idx === currentIndex ? 'active' : ''}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setCurrentIndex(idx);
+                    resetViewState();
+                  }}
+                />
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Overlay carousel arrows on images and add clickable dots for each photo
- Allow scrolling on mobile when image not zoomed by toggling touch-action
- Remove image rotation feature and obsolete controls

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9d2cc4c388333b10d184731e92fdd