### PR TITLE
Use profile icon on mobile navigation

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -11,6 +11,21 @@
   gap: 0.75rem;
 }
 
+/* Texte/icone du bouton profil */
+.main-nav .profile-icon {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .main-nav .profile-text {
+    display: none;
+  }
+  .main-nav .profile-icon {
+    display: inline;
+    font-size: 1.5rem;
+  }
+}
+
 .App {
   position: relative; /* Contexte de positionnement pour les éléments absolus */
   width: 100%;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -309,10 +309,15 @@ const handleProfileReset = () => {
         />
       )}
       <nav className="main-nav">
-          <button onClick={() => {
+          <button
+            className="profile-button"
+            onClick={() => {
               setIsProfileVisible(true);
-            }}>
-            Mon Profil
+            }}
+            aria-label="Mon Profil"
+          >
+            <span className="profile-text">Mon Profil</span>
+            <span className="profile-icon" aria-hidden="true">👤</span>
           </button>
       </nav>
       <header className="app-header">


### PR DESCRIPTION
## Summary
- show a profile icon instead of text for the profile button on small screens
- add responsive CSS for hiding text on narrow viewports

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd9ce2c08333921c9f4ddddc86d8