### PR TITLE
feat: overlay carousel controls

### DIFF
--- a/client/src/components/ImageViewer.css
+++ b/client/src/components/ImageViewer.css
@@ -32,11 +32,23 @@
   z-index: 0;
 }
 
-/* Boutons de navigation placés au-dessus de l'image */
-.nav-button {
+/* Overlay regroupant flèches et points */
+.nav-overlay {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-radius: 9999px;
+  z-index: 1;
+}
+
+/* Boutons de navigation */
+.nav-button {
   background-color: rgba(0, 0, 0, 0.5);
   border: none;
   color: #fff;
@@ -49,15 +61,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1;
-}
-
-.nav-button.prev {
-  left: 10px;
-}
-
-.nav-button.next {
-  right: 10px;
 }
 
 .nav-button:disabled {
@@ -67,13 +70,8 @@
 
 /* Points de navigation */
 .dots {
-  position: absolute;
-  bottom: 10px;
-  left: 50%;
-  transform: translateX(-50%);
   display: flex;
   gap: 8px;
-  z-index: 1;
 }
 
 .dot {

--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -228,7 +228,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
           <div className="image-placeholder" />
         )}
         {imageUrls.length > 1 && (
-          <div className="nav-overlay">
+          <div className="nav-overlay" role="group" aria-label="Contrôles de navigation">
             <button
               type="button"
               className="nav-button prev"
@@ -239,17 +239,6 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
               }}
             >
               ‹
-            </button>
-            <button
-              type="button"
-              className="nav-button next"
-              aria-label="Image suivante"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleNext();
-              }}
-            >
-              ›
             </button>
             <div className="dots" role="tablist" aria-label="Choix de l'image">
               {imageUrls.map((_, idx) => (
@@ -267,6 +256,17 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
                 />
               ))}
             </div>
+            <button
+              type="button"
+              className="nav-button next"
+              aria-label="Image suivante"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleNext();
+              }}
+            >
+              ›
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- place navigation controls over images in viewer
- center dots and arrows within a translucent overlay

## Testing
- `npm test` (fails: no test specified)
- `npm --prefix client run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a9dd6af69883338546db1d88c2f04a