### PR TITLE
Adjust modals to better fit mobile screens

### DIFF
--- a/client/src/components/HelpModal.css
+++ b/client/src/components/HelpModal.css
@@ -81,9 +81,10 @@
 }
 
 @media (max-width: 480px) {
-  .modal-content {
+  .modal-content.help-modal {
+    width: 90%;
     padding: var(--space-3);
-    max-height: 90vh;
+    max-height: 80vh;
     overflow-y: auto;
   }
   .modal-title {

--- a/client/src/components/HelpModal.jsx
+++ b/client/src/components/HelpModal.jsx
@@ -23,7 +23,7 @@ function HelpModal({ onClose }) {
     // Le fond assombri qui ferme le modal au clic
     <div className="modal-backdrop" onClick={onClose} role="dialog" aria-modal="true">
       {/* On empêche la propagation du clic pour que le modal ne se ferme pas quand on clique dessus */}
-      <div className="modal-content" tabIndex="-1" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-content help-modal" tabIndex="-1" onClick={(e) => e.stopPropagation()}>
         <button onClick={onClose} className="close-button" title="Fermer" aria-label="Fermer">×</button>
         
         <h2 className="modal-title">Bienvenue sur Inaturaquizz !</h2>

--- a/client/src/components/ProfileModal.css
+++ b/client/src/components/ProfileModal.css
@@ -204,3 +204,10 @@
 .achievement-title { margin: 0; font-size: 1.1rem; font-weight: 600; }
 .achievement-item.unlocked .achievement-title { color: var(--accent-color); }
 .achievement-description { margin: 0; font-size: 0.9rem; color: var(--text-color-muted); }
+@media (max-width: 480px) {
+  .modal-content.profile-modal {
+    width: 90%;
+    padding: var(--space-3);
+    max-height: 80vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Prevent HelpModal and ProfileModal from occupying the entire screen on small devices
- Add mobile-specific sizing rules with reduced max-height and padding

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f67cee888333a872c38c9a3857d4