### PR TITLE
Limit image size and optimize image loading

### DIFF
--- a/client/src/components/ImageViewer.css
+++ b/client/src/components/ImageViewer.css
@@ -1,15 +1,18 @@
 /* Conteneur global */
 .image-viewer-container {
   width: 100%;
-  height: 100%;
+  height: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 /* Wrapper : base pour centrer la box, pas la cible de l'overlay */
 .image-viewer-container .image-wrapper {
-  flex-grow: 1;
+  flex-grow: 0;
   width: 100%;
+  max-width: 600px;
+  max-height: 75vh;
   background-color: var(--bg-color, #0b0b0b);
   border-radius: var(--border-radius, 12px);
   border: 2px solid var(--border-color, rgba(255,255,255,0.1));
@@ -29,6 +32,7 @@
   display: inline-block !important; /* shrink-to-fit */
   line-height: 0 !important;
   max-width: 100% !important;       /* la photo ne dépasse pas le wrapper */
+  max-height: 100% !important;
 }
 
 /* L'image ne doit pas étirer .image-box :
@@ -36,6 +40,7 @@
       limitée par le parent. */
 .image-viewer-container .image-wrapper .image-box > img {
   max-width: 100% !important;
+  max-height: 100% !important;
   height: auto !important;
   user-select: none;
   -webkit-user-drag: none;
@@ -61,6 +66,8 @@
   z-index: 10 !important;            /* au-dessus de l'image */
   backdrop-filter: blur(2px);
   pointer-events: auto;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 /* Boutons de navigation */

--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -10,7 +10,8 @@ const Fallback = {
     position: 'absolute', left: '50%', bottom: '12px', transform: 'translateX(-50%)',
     display: 'flex', alignItems: 'center', gap: '8px',
     padding: '6px 10px', background: 'rgba(0,0,0,0.4)', borderRadius: '9999px',
-    zIndex: 10, backdropFilter: 'blur(2px)'
+    zIndex: 10, backdropFilter: 'blur(2px)',
+    maxWidth: '100%', boxSizing: 'border-box'
   },
   arrow: {
     width: '36px', height: '36px', borderRadius: '999px', border: 'none',
@@ -55,7 +56,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
     const link = document.createElement('link');
     link.rel = 'preload';
     link.as = 'image';
-    link.href = getSizedImageUrl(nextImageUrl, 'large');
+    link.href = getSizedImageUrl(nextImageUrl, 'medium');
     document.head.appendChild(link);
     return () => { document.head.removeChild(link); };
   }, [nextImageUrl]);
@@ -173,8 +174,8 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
         {/* NOUVEAU CONTENEUR QUI ÉPOUSE LA PHOTO */}
         <div className="image-box">
           <img
-            src={getSizedImageUrl(imageUrls[currentIndex], 'large')}
-            srcSet={`${getSizedImageUrl(imageUrls[currentIndex], 'small')} 300w, ${getSizedImageUrl(imageUrls[currentIndex], 'medium')} 600w, ${getSizedImageUrl(imageUrls[currentIndex], 'large')} 1024w`}
+            src={getSizedImageUrl(imageUrls[currentIndex], 'medium')}
+            srcSet={`${getSizedImageUrl(imageUrls[currentIndex], 'small')} 300w, ${getSizedImageUrl(imageUrls[currentIndex], 'medium')} 600w`}
             sizes="(max-width: 600px) 100vw, 600px"
             alt={alt}
             loading="lazy"
@@ -183,6 +184,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
             onLoad={handleImageLoad}
             style={{
               width: '100%',
+              maxHeight: '100%',
               aspectRatio,
               transform: `translateX(${transform.x}px) translateY(${transform.y}px) scale(${scale})`,
               transition: (isPanning.current || initialPinchDistance.current) ? 'none' : 'transform 0.3s ease',

--- a/client/src/components/RoundSummaryModal.css
+++ b/client/src/components/RoundSummaryModal.css
@@ -59,6 +59,7 @@
     width: 100%;
     aspect-ratio: 4 / 3;
     height: auto;
+    max-height: 300px;
     object-fit: cover;
     border-radius: 8px;
     margin: var(--space-2) 0;

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -56,15 +56,14 @@ const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
         <div className="correct-answer-section">
           <p>La réponse était :</p>
           <img
-            src={getSizedImageUrl(imageUrl, 'large')}
-            srcSet={`${getSizedImageUrl(imageUrl, 'small')} 300w, ${getSizedImageUrl(imageUrl, 'medium')} 600w, ${getSizedImageUrl(imageUrl, 'large')} 1024w`}
+            src={getSizedImageUrl(imageUrl, 'medium')}
+            srcSet={`${getSizedImageUrl(imageUrl, 'small')} 300w, ${getSizedImageUrl(imageUrl, 'medium')} 600w`}
             sizes="(max-width: 600px) 100vw, 400px"
             alt={commonName || scientificName}
             className="answer-image"
             loading="lazy"
             decoding={imageUrl ? 'async' : undefined}
             fetchpriority={imageUrl ? 'high' : undefined}
-            style={{ width: '100%', aspectRatio: '4 / 3' }}
           />
           
           {/* On affiche le nom commun que s'il existe ET est différent du nom scientifique */}


### PR DESCRIPTION
## Summary
- constrain image viewer dimensions and adapt overlay layout
- load medium-resolution images with small fallbacks to reduce bandwidth
- cap round summary image height for improved ergonomics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac3ffc4b208333ba5ef290a691323a