### PR TITLE
Use prefetch for next image to avoid preload warnings

### DIFF
--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -54,11 +54,15 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
   useEffect(() => {
     if (!nextImageUrl) return;
     const link = document.createElement('link');
-    link.rel = 'preload';
+    // Use "prefetch" instead of "preload" to avoid browser warnings when the
+    // next image isn't displayed quickly enough.
+    link.rel = 'prefetch';
     link.as = 'image';
     link.href = getSizedImageUrl(nextImageUrl, 'medium');
     document.head.appendChild(link);
-    return () => { document.head.removeChild(link); };
+    return () => {
+      document.head.removeChild(link);
+    };
   }, [nextImageUrl]);
 
   const resetViewState = () => {


### PR DESCRIPTION
## Summary
- Avoid browser warnings by replacing next image preload with prefetch in `ImageViewer`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac439b4e9883339c5af5adec223b9d