### PR TITLE
fix: exclude assets from SPA redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,6 +19,12 @@
   status = 200
   force  = true
 
+# Exclude assets from SPA fallback
+[[redirects]]
+  from = "/assets/*"
+  to   = "/assets/:splat"
+  status = 200
+
 # SPA fallback pour le routage client
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Summary
- ensure netlify doesn't route asset requests through SPA fallback

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*
- `npx netlify --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac43b04c9c83339dd0a850a563939e