### PR TITLE
feat: handle lazy loading fallback

### DIFF
--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -2,6 +2,12 @@ import React, { useState, useRef, useEffect } from 'react';
 import './ImageViewer.css';
 import { getSizedImageUrl } from '../utils/imageUtils';
 
+// Detect native support for the `loading="lazy"` attribute.
+// Fallback: when unsupported (e.g. Safari), the image loads immediately.
+// An IntersectionObserver could be used here instead to emulate lazy loading.
+const supportsLazyLoading =
+  typeof HTMLImageElement !== 'undefined' && 'loading' in HTMLImageElement.prototype;
+
 const MAX_ZOOM = 2.5;
 
 // Fallback inline styles (au cas où le CSS ne serait pas appliqué)
@@ -182,7 +188,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
             srcSet={`${getSizedImageUrl(imageUrls[currentIndex], 'small')} 300w, ${getSizedImageUrl(imageUrls[currentIndex], 'medium')} 600w`}
             sizes="(max-width: 600px) 100vw, 600px"
             alt={alt}
-            loading="lazy"
+            {...(supportsLazyLoading ? { loading: 'lazy' } : {})}
             decoding={currentIndex === 0 ? 'async' : undefined}
             fetchPriority={currentIndex === 0 ? 'high' : undefined}
             onLoad={handleImageLoad}

--- a/client/src/components/RoundSummaryModal.jsx
+++ b/client/src/components/RoundSummaryModal.jsx
@@ -2,6 +2,12 @@ import React, { useEffect, useRef } from 'react';
 import './RoundSummaryModal.css';
 import { getSizedImageUrl } from '../utils/imageUtils';
 
+// Detect support for native lazy-loading on images.
+// Fallback: without support (e.g. Safari), images load immediately.
+// An IntersectionObserver could be used here to manually defer loading.
+const supportsLazyLoading =
+  typeof HTMLImageElement !== 'undefined' && 'loading' in HTMLImageElement.prototype;
+
 
 // Affiche le récapitulatif d'une manche avec le résultat (victoire/défaite)
 const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
@@ -61,7 +67,7 @@ const RoundSummaryModal = ({ status, question, scoreInfo, onNext }) => {
             sizes="(max-width: 600px) 100vw, 400px"
             alt={commonName || scientificName}
             className="answer-image"
-            loading="lazy"
+            {...(supportsLazyLoading ? { loading: 'lazy' } : {})}
             decoding={imageUrl ? 'async' : undefined}
             fetchpriority={imageUrl ? 'high' : undefined}
           />


### PR DESCRIPTION
## Summary
- detect native lazy-loading support in image components
- fallback to eager loading when unsupported (e.g. Safari)

## Testing
- `npm test`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac50ffb04c833392d4f32c4550fcb3