### PR TITLE
Limit height of vertical images in quiz viewer

### DIFF
--- a/client/src/components/ImageViewer.css
+++ b/client/src/components/ImageViewer.css
@@ -26,6 +26,11 @@
   z-index: 0;
 }
 
+/* Limite la hauteur des images verticales pour une meilleure UX */
+.image-viewer-container .image-wrapper.portrait {
+  max-height: 60vh;
+}
+
 /* La boîte épouse la taille effective de la photo */
 .image-viewer-container .image-wrapper .image-box {
   position: relative !important;

--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -37,6 +37,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
   const [transform, setTransform] = useState({ x: 0, y: 0 });
   const [isLoaded, setIsLoaded] = useState(true);
   const [aspectRatio, setAspectRatio] = useState();
+  const [isPortrait, setIsPortrait] = useState(false);
 
   const containerRef = useRef(null);
   const isPanning = useRef(false);
@@ -51,6 +52,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
     setScale(1);
     setTransform({ x: 0, y: 0 });
     setIsLoaded(true);
+    setIsPortrait(false);
   }, [imageUrls]);
 
   useEffect(() => {
@@ -150,7 +152,10 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
   const handleImageLoad = (e) => {
     setIsLoaded(true);
     const { naturalWidth, naturalHeight } = e.target;
-    if (naturalWidth && naturalHeight) setAspectRatio(`${naturalWidth} / ${naturalHeight}`);
+    if (naturalWidth && naturalHeight) {
+      setAspectRatio(`${naturalWidth} / ${naturalHeight}`);
+      setIsPortrait(naturalHeight > naturalWidth);
+    }
   };
 
   const handleKeyDown = (e) => {
@@ -167,7 +172,7 @@ function ImageViewer({ imageUrls, alt, nextImageUrl }) {
     <div className="image-viewer-container">
       <div
         ref={containerRef}
-        className="image-wrapper"
+        className={`image-wrapper ${isPortrait ? 'portrait' : ''}`}
         style={{ touchAction: scale > 1 ? 'none' : 'pan-y' }}
         onClick={handleImageClick}
         onPointerDown={handlePointerDown}


### PR DESCRIPTION
## Summary
- Detect portrait-oriented images in quiz ImageViewer and flag them as `portrait`
- Constrain portrait images to a shorter `max-height` for better UX

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac530e28888333a6f6cc05fd9dd513