### PR TITLE
Allow static image hosts in CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -64,7 +64,7 @@
   [headers.values]
     Referrer-Policy = "strict-origin-when-cross-origin"
     # NOTE: on autorise explicitement https://inaturamouche.onrender.com dans connect-src
-    Content-Security-Policy = "default-src 'self'; connect-src 'self' https://api.inaturalist.org https://inaturamouche.onrender.com; img-src 'self' data: https: https://static.inaturalist.org https://inaturalist-open-data.s3.amazonaws.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https: data: https://fonts.gstatic.com; script-src 'self'; worker-src 'self' blob:; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; connect-src 'self' https://api.inaturalist.org https://inaturamouche.onrender.com https://static.inaturalist.org https://inaturalist-open-data.s3.amazonaws.com; img-src 'self' data: https: https://static.inaturalist.org https://inaturalist-open-data.s3.amazonaws.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https: data: https://fonts.gstatic.com; script-src 'self'; worker-src 'self' blob:; frame-ancestors 'none'"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
     Cross-Origin-Opener-Policy = "same-origin-allow-popups"


### PR DESCRIPTION
## Summary
- expand Content Security Policy to permit image requests from static.inaturalist.org and inaturalist-open-data.s3.amazonaws.com

## Testing
- `npm test` *(fails: no test specified)*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac54482f6483338c3747f00c5282c0