### PR TITLE
Center navigation arrows in image viewer buttons

### DIFF
--- a/client/src/components/ImageViewer.css
+++ b/client/src/components/ImageViewer.css
@@ -86,10 +86,11 @@
   border-radius: 50%;
   width: 36px;
   height: 36px;
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background .2s ease, transform .1s ease;
-  line-height: 0;
+  line-height: 1;
 }
 .image-viewer-container .image-wrapper .nav-button:hover { background-color: rgba(255,255,255,0.22); }
 .image-viewer-container .image-wrapper .nav-button:active { transform: scale(0.96); }

--- a/client/src/components/ImageViewer.jsx
+++ b/client/src/components/ImageViewer.jsx
@@ -22,7 +22,11 @@ const Fallback = {
   arrow: {
     width: '36px', height: '36px', borderRadius: '999px', border: 'none',
     background: 'rgba(255,255,255,0.14)', color: '#fff', fontSize: '20px',
-    lineHeight: 1, display: 'grid', placeItems: 'center', cursor: 'pointer'
+    lineHeight: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer'
   },
   dots: { display: 'flex', alignItems: 'center', gap: '8px' },
   dot: {


### PR DESCRIPTION
## Summary
- Center image viewer navigation arrows vertically within their buttons

## Testing
- `npm test`
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac570cc5548333a9009109c197859d