### PR TITLE
feat: place easy-mode choices beside image on desktop

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -166,6 +166,22 @@ button:focus-visible {
 .game-main { display: flex; flex-direction: column; gap: 1rem; width: 100%; flex-grow: 1; }
 .image-section { display: flex; flex-direction: column; gap: 0.75rem; }
 .choices { width: 100%; display: grid; grid-template-columns: 1fr; gap: 0.75rem; flex-shrink: 0; margin-top: auto; }
+
+@media (min-width: 768px) {
+  .game-main {
+    flex-direction: row-reverse;
+    align-items: flex-start;
+  }
+
+  .choices {
+    width: 40%;
+    margin-top: 0;
+  }
+
+  .image-section {
+    width: 60%;
+  }
+}
   .inat-link { display: inline-flex; align-self: center; gap: 8px; padding: var(--space-2) calc(var(--space-2) + var(--space-1)); background-color: rgba(0, 0, 0, 0.2); border-radius: 8px; color: var(--text-color-muted); text-decoration: none; font-size: 0.9rem; font-weight: 500; transition: all 0.2s; }
 .inat-link:hover { background-color: var(--primary-color); color: var(--text-color); }
 .end-screen .card { text-align: center; }


### PR DESCRIPTION
## Summary
- align easy-mode answer choices to the left of the image on wider screens
- keep choices below the image on mobile devices

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac5775e5908333b3feb91a17d63ec8