### PR TITLE
Adjust portrait image sizing and easy-mode layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -160,6 +160,8 @@ button:focus-visible {
 
 /* --- AUTRES STYLES (inchangés ou mineurs) --- */
 .game-screen .card { flex-grow: 1; }
+.game-screen.easy-mode .card { flex-grow: 0; }
+.game-screen.easy-mode .game-main { flex-grow: 0; }
 .game-header { width: 100%; display: flex; justify-content: space-between; align-items: center; font-size: 1.1rem; font-weight: 600; flex-shrink: 0; }
 .score-container { display: flex; align-items: center; gap: 0.5rem; }
 .score { color: var(--accent-color); font-weight: 700; }

--- a/client/src/components/Easymode.jsx
+++ b/client/src/components/Easymode.jsx
@@ -70,7 +70,7 @@ const EasyMode = ({ question, score, questionCount, onAnswer, onUpdateScore, nex
         />
       )}
 
-      <div className="screen game-screen">
+      <div className="screen game-screen easy-mode">
         <div className="card">
           <header className="game-header">
             <div className="header-left">

--- a/client/src/components/ImageViewer.css
+++ b/client/src/components/ImageViewer.css
@@ -28,7 +28,7 @@
 
 /* Limite la hauteur des images verticales pour une meilleure UX */
 .image-viewer-container .image-wrapper.portrait {
-  max-height: 60vh;
+  max-height: 55vh;
 }
 
 /* La boîte épouse la taille effective de la photo */


### PR DESCRIPTION
## Summary
- Reduce portrait image viewer height for better fit
- Tweak EasyMode layout to remove extra space on desktop

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix client test` *(fails: missing script: test)*
- `npm --prefix client run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac8bede41c8333a8f01fbe726f3afd