### PR TITLE
Allow multiple taxon parameters in quiz API

### DIFF
--- a/server.js
+++ b/server.js
@@ -264,11 +264,13 @@ function asyncRoute(handler) {
 }
 
 /* -------------------- Validation (Zod) -------------------- */
+const stringOrArray = z.union([z.string(), z.array(z.string())]);
+
 const quizSchema = z.object({
   pack_id: z.string().optional(),
-  taxon_ids: z.string().optional(),
-  include_taxa: z.string().optional(),
-  exclude_taxa: z.string().optional(),
+  taxon_ids: stringOrArray.optional(),
+  include_taxa: stringOrArray.optional(),
+  exclude_taxa: stringOrArray.optional(),
   lat: z.coerce.number().min(-90).max(90).optional(),
   lng: z.coerce.number().min(-180).max(180).optional(),
   radius: z.coerce.number().min(1).max(200).optional(),
@@ -284,9 +286,9 @@ const autocompleteSchema = z.object({
 });
 
 const speciesCountsSchema = z.object({
-  taxon_ids: z.string().optional(),
-  include_taxa: z.string().optional(),
-  exclude_taxa: z.string().optional(),
+  taxon_ids: stringOrArray.optional(),
+  include_taxa: stringOrArray.optional(),
+  exclude_taxa: stringOrArray.optional(),
   lat: z.coerce.number().min(-90).max(90).optional(),
   lng: z.coerce.number().min(-180).max(180).optional(),
   radius: z.coerce.number().min(1).max(200).optional(),


### PR DESCRIPTION
## Summary
- accept array or string for taxon filter params in quiz and species count schemas so repeated `taxon_ids` etc. no longer trigger 400

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90afc56c83338ffa16e67ab1e73b