### PR TITLE
Fix restart handler to preserve custom filters

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -362,7 +362,7 @@ const handleProfileReset = () => {
               sessionCorrectSpecies={sessionCorrectSpecies}
               sessionSpeciesData={sessionSpeciesData}
               newlyUnlocked={newlyUnlocked}
-              onRestart={startGame}
+              onRestart={() => startGame(false)}
               onReturnHome={returnToConfig}
             />
           ) : (


### PR DESCRIPTION
## Summary
- Avoid passing click event to `startGame` when restarting, preserving custom filters

## Testing
- `npm test` (fails: Error: no test specified)
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adf5ee18548333a447290cd6af97cb