### PR TITLE
Fix place autocomplete requests to API base

### DIFF
--- a/client/src/components/GeoFilter.jsx
+++ b/client/src/components/GeoFilter.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { MapContainer, TileLayer, Rectangle, useMapEvents } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import { autocompletePlaces } from "../services/api";
 
 function BBoxSelector({ value, onChange }) {
   const [bounds, setBounds] = useState(null);
@@ -60,8 +61,8 @@ export default function GeoFilter({ value, onChange, initialCenter = [48.85, 2.3
     const t = setTimeout(async () => {
       setLoading(true);
       try {
-        const r = await fetch(`/api/places?q=${encodeURIComponent(query)}&per_page=15`);
-        setSuggestions(await r.json());
+        const results = await autocompletePlaces(query, 15);
+        setSuggestions(results);
       } catch (_) {
         /* ignore network errors */
       }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -49,6 +49,15 @@ export const autocompleteTaxa = (query, extraParams = {}, locale = 'fr') => {
 };
 
 /**
+ * Récupère une liste de lieux pour l'autocomplétion.
+ * @param {string} query - Le terme de recherche.
+ * @param {number} perPage - Nombre maximum de résultats.
+ * @returns {Promise<Array>} Une liste de lieux.
+ */
+export const autocompletePlaces = (query, perPage = 15) =>
+  apiGet('/api/places', { q: query, per_page: perPage });
+
+/**
  * Récupère les détails pour plusieurs taxons en un seul appel.
  * @param {Array<string|number>} ids - Un tableau d'IDs de taxons.
  * @param {string} locale - La langue souhaitée.


### PR DESCRIPTION
## Summary
- Use shared API base when querying places autocomplete
- Expose `autocompletePlaces` helper and integrate it in GeoFilter

## Testing
- `npm test` *(fails: no test specified)*
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aee75172388333a734c792a6a89510