### PR TITLE
style: match place filter pill styling

### DIFF
--- a/client/src/components/GeoFilter.jsx
+++ b/client/src/components/GeoFilter.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import L from "leaflet";
@@ -355,34 +355,19 @@ export default function GeoFilter({
 
       {tab === "place" && (
         <div style={{ display: "grid", gap: 8 }}>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          <div className="pills-container place-pills">
             {selected.map((p) => (
-              <span
-                key={p.id}
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 6,
-                  padding: "4px 8px",
-                  border: "1px solid #ccc",
-                  borderRadius: 999,
-                }}
-              >
+              <div key={p.id} className="taxon-pill">
                 <span>{p.name}</span>
                 <button
                   type="button"
                   aria-label={`Retirer ${p.name}`}
+                  className="remove-btn"
                   onClick={() => removePlace(p.id)}
-                  style={{
-                    border: "none",
-                    background: "transparent",
-                    cursor: "pointer",
-                    fontWeight: 700,
-                  }}
                 >
                   ×
                 </button>
-              </span>
+              </div>
             ))}
           </div>
 

--- a/client/src/configurator.css
+++ b/client/src/configurator.css
@@ -150,6 +150,7 @@
 }
 .include-pills .taxon-pill { background-color: #2a4b37; }
 .exclude-pills .taxon-pill { background-color: #581e1e; }
+.place-pills .taxon-pill { background-color: #2a4b37; }
 .taxon-pill .remove-btn {
   background: rgba(255, 255, 255, 0.2);
   border: none;


### PR DESCRIPTION
## Summary
- style place filter selections with the same pill UI as taxon filter
- add place pill style definition

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aef4602f208333a75e27fabc4925f9